### PR TITLE
Fix liquibase breaking change

### DIFF
--- a/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
+++ b/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
@@ -11,10 +11,29 @@
     <property name="autoIncrement" value="true"/>
 
     <changeSet id="00000000000000" author="nivethika@thehyve.nl" dbms="postgresql,oracle,h2">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sequenceExists sequenceName="hibernate_sequence"/>
+            </not>
+        </preConditions>
         <createSequence sequenceName="hibernate_sequence" startValue="1000" incrementBy="50"/>
     </changeSet>
 
     <changeSet id="00000000000001" author="nivethika@thehyve.nl">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="rest_source_user"/>
+            </not>
+            <not>
+                <indexExists indexName="idx_rest_source_user_id"/>
+            </not>
+            <not>
+                <indexExists indexName="idx_rest_source_user_external_id"/>
+            </not>
+            <not>
+                <indexExists indexName="idx_rest_source_user_source_id"/>
+            </not>
+        </preConditions>
         <createTable tableName="rest_source_user">
             <column name="id" type="bigint" autoIncrement="${autoIncrement}">
                 <constraints primaryKey="true" nullable="false"/>


### PR DESCRIPTION
Fixes #18 

This was because of a breaking change when migrating from liquibase 3.5.x to 3.6.x which happened due to this PR #16 . Reverting to spring boot 2.0.5 also fixes this but i think it's better to keep it updated.
There was a change in how the checksum logic is calculated and hence we need to use the exists clause for each database create query. 
We also mark transaction as `MARK_RAN` so that liquibase will not try to run it again next if the pre-conditions fail.