### PR TITLE
Fix changelog filename inconsistencies

### DIFF
--- a/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
+++ b/src/main/resources/db/changelog/changes/00000000000000_initial_schema.xml
@@ -10,11 +10,11 @@
     <property name="now" value="current_timestamp" dbms="postgresql"/>
     <property name="autoIncrement" value="true"/>
 
-    <changeSet id="00000000000000" author="nivethika@thehyve.nl" dbms="postgresql,oracle,h2">
+    <changeSet id="00000000000000" logicalFilePath="db/changelog/changes/00000000000000_initial_schema.xml" author="nivethika@thehyve.nl" dbms="postgresql,oracle,h2">
         <createSequence sequenceName="hibernate_sequence" startValue="1000" incrementBy="50"/>
     </changeSet>
 
-    <changeSet id="00000000000001" author="nivethika@thehyve.nl">
+    <changeSet id="00000000000001" logicalFilePath="db/changelog/changes/00000000000000_initial_schema.xml" author="nivethika@thehyve.nl">
         <createTable tableName="rest_source_user">
             <column name="id" type="bigint" autoIncrement="${autoIncrement}">
                 <constraints primaryKey="true" nullable="false"/>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,3 +1,3 @@
 databaseChangeLog:
-    - includeAll:
-        path: db/changelog/changes/
+    - include:
+       file: db/changelog/changes/00000000000000_initial_schema.xml


### PR DESCRIPTION
- add explicit inclusion of changelog files
- add `logicalFilePath` to every `changeSet`


The actual fix is **fixing the inconsistencies on the database level.** 
**PLEASE MAKE A BACK-UP OF THE DATABASE BEFORE MODIFYING THIS ON PRODUCTION**
Here are the steps. ( Assuming you are using RADAR-Docker installation)

```shell
docker-compose exec radarbase-postgresql /bin/sh
/ # psql -U radarbase restsourceauthorizer 
restsourceauthorizer=# \dt
                 List of relations
 Schema |         Name          | Type  |   Owner   
--------+-----------------------+-------+-----------
 public | databasechangelog     | table | radarbase
 public | databasechangeloglock | table | radarbase
 public | rest_source_user      | table | radarbase
(3 rows)
restsourceauthorizer-# select * from databasechangelog;
restsourceauthorizer=# select * from databasechangelog;
       id       |        author        |                                filename                                 |        dateexecuted        | orderexecuted | exectype |               md5sum               |                                                                                                                        description                                                                                                                         | comments | tag | liquibase | contexts | labels | deployment_id 
----------------+----------------------+-------------------------------------------------------------------------+----------------------------+---------------+----------+------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-----+-----------+----------+--------+---------------
 00000000000000 | nivethika@thehyve.nl | BOOT-INF/classes/db/changelog/changes/00000000000000_initial_schema.xml | 2019-03-15 10:16:46.099989 |             1 | EXECUTED | 7:a6235f40597a13436aa36c6d61db2269 | createSequence sequenceName=hibernate_sequence                                                                                                                                                                                                             |          |     | 3.5.4     |          |        | 2645005738
 00000000000001 | nivethika@thehyve.nl | BOOT-INF/classes/db/changelog/changes/00000000000000_initial_schema.xml | 2019-03-15 10:16:46.501098 |             2 | EXECUTED | 7:7017a75f4e656fc266fd69b3200f1601 | createTable tableName=rest_source_user; createIndex indexName=idx_rest_source_user_id, tableName=rest_source_user; createIndex indexName=idx_rest_source_user_external_id, tableName=rest_source_user; createIndex indexName=idx_rest_source_user_sourc... |          |     | 3.5.4     |          |        | 2645005738
(2 rows)

restsourceauthorizer=# update databasechangelog set filename = replace(filename, 'BOOT-INF/classes/db/changelog/changes/00000000000000_initial_schema.xml', 'db/changelog/changes/00000000000000_initial_schema.xml');
UPDATE 2
restsourceauthorizer=# select * from databasechangelog;
       id       |        author        |                        filename                        |        dateexecuted        | orderexecuted | exectype |               md5sum               |                                                                                                                        description                                                                                                                         | comments | tag | liquibase | contexts | labels | deployment_id 
----------------+----------------------+--------------------------------------------------------+----------------------------+---------------+----------+------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+-----+-----------+----------+--------+---------------
 00000000000000 | nivethika@thehyve.nl | db/changelog/changes/00000000000000_initial_schema.xml | 2019-03-15 10:16:46.099989 |             1 | EXECUTED | 7:a6235f40597a13436aa36c6d61db2269 | createSequence sequenceName=hibernate_sequence                                                                                                                                                                                                             |          |     | 3.5.4     |          |        | 2645005738
 00000000000001 | nivethika@thehyve.nl | db/changelog/changes/00000000000000_initial_schema.xml | 2019-03-15 10:16:46.501098 |             2 | EXECUTED | 7:7017a75f4e656fc266fd69b3200f1601 | createTable tableName=rest_source_user; createIndex indexName=idx_rest_source_user_id, tableName=rest_source_user; createIndex indexName=idx_rest_source_user_external_id, tableName=rest_source_user; createIndex indexName=idx_rest_source_user_sourc... |          |     | 3.5.4     |          |        | 2645005738
(2 rows)

restsourceauthorizer=# \q
/ # exit

```
This will fix the inconsistencies in the filename. 
Now you can change the [radar-rest-authorizer-backend:1.1.0](https://github.com/RADAR-base/RADAR-Docker/blob/dev/dcompose-stack/radar-cp-hadoop-stack/optional-services.yml#L77)
then restart the container
```code
 bin/radar-docker up -d radar-rest-sources-backend
```
