### PR TITLE
Fixes for URL paths

### DIFF
--- a/src/main/java/org/radarbase/authorizer/config/ManagementPortalProperties.java
+++ b/src/main/java/org/radarbase/authorizer/config/ManagementPortalProperties.java
@@ -20,6 +20,17 @@ public class ManagementPortalProperties {
   @NotNull
   private String oauthClientSecret;
 
+  @NotNull
+  private String tokenPath;
+
+  public String getTokenPath() {
+    return tokenPath;
+  }
+
+  public void setTokenPath(String tokenPath) {
+    this.tokenPath = tokenPath;
+  }
+
   public String getBaseUrl() {
     return baseUrl;
   }
@@ -79,5 +90,17 @@ public class ManagementPortalProperties {
   @Override
   public int hashCode() {
     return Objects.hash(baseUrl, projectsPath, subjectsPath, oauthClientId, oauthClientSecret);
+  }
+
+  @Override
+  public String toString() {
+    return "ManagementPortalProperties{" +
+        "baseUrl='" + baseUrl + '\'' +
+        ", projectsPath='" + projectsPath + '\'' +
+        ", subjectsPath='" + subjectsPath + '\'' +
+        ", oauthClientId='" + oauthClientId + '\'' +
+        ", oauthClientSecret='" + oauthClientSecret + '\'' +
+        ", tokenPath='" + tokenPath + '\'' +
+        '}';
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,8 +25,9 @@ rest-source-authorizer:
 
   validator: managementportal
   management-portal:
-    base-url: "http://localhost:8081"
-    projects-path: "/projects"
-    subjects-path: "/subjects"
+    base-url: "http://localhost:8081/"
+    projects-path: "api/projects"
+    subjects-path: "api/subjects"
+    token_path: "oauth/token"
     oauth-client-id: "radar_rest_sources_auth"
     oauth-client-secret: "secret"


### PR DESCRIPTION
- also verifies the connection and token privileges on start of the application (helps report and diagnose problems before start using it)
-  makes token path configurable

This is needed because of the `URL` constructor `URL(context, spec)`. If the spec has a `/` in the begining then it will replace the path in the context. Hence when creating `new URL("http://managementportal-app:8080/managementportal", "/oauth/token")`, the `/managementportal` path was being discarded. see [official docs](https://docs.oracle.com/javase/7/docs/api/java/net/URL.html#URL(java.net.URL,%20java.lang.String)) for more info


Migration Steps involving validation
-

### If don't need validation
Add the `REST_SOURCE_AUTHORIZER_VALIDATOR` env var to your docker-compose service to disable validation-
```yaml
  radar-rest-sources-backend:
    image: radarbase/radar-rest-source-auth-backend:1.2.1
...
    environment:
...
      - REST_SOURCE_AUTHORIZER_VALIDATOR=""
    volumes:
      - ./etc/rest-source-authorizer/:/app-includes/
...

```
**Note: This will only disable backend validation. The frontend validation(based on Regex) will still exist.**

### Enable validation using Management Portal

#### First Create a new oAuth client in Management Portal
To add new OAuth clients, you can add at runtime through the UI on Management Portal, or you can add them to the OAuth clients file referenced by the MANAGEMENTPORTAL_OAUTH_CLIENTS_FILE configuration option.

#### Then add the following to your rest authoriser service
Add the following env vars to your docker-compose service-
```yaml
  radar-rest-sources-backend:
    image: radarbase/radar-rest-source-auth-backend:1.2.1
...
    environment:
...
      - REST_SOURCE_AUTHORIZER_VALIDATOR=managementportal
      - REST_SOURCE_AUTHORIZER_MANAGEMENT_PORTAL_BASE_URL=http://managementportal-app:8080/managementportal/
      - REST_SOURCE_AUTHORIZER_MANAGEMENT_PORTAL_OAUTH_CLIENT_ID=radar_rest_sources_auth
      - REST_SOURCE_AUTHORIZER_MANAGEMENT_PORTAL_OAUTH_CLIENT_SECRET=secret
    volumes:
      - ./etc/rest-source-authorizer/:/app-includes/
...
```

**Note**: Make sure to configure the client id and client secret as created in the Management portal