### PR TITLE
Add endpoint for signing OAuth1 requests

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
@@ -41,6 +41,12 @@ data class RestOauth1UserId(
     @JsonProperty("userId") var userId: String,
 )
 
+data class SignRequestParams(
+    var url: String,
+    var method: String,
+    val params: MutableMap<String, String?>
+)
+
 data class RequestTokenPayload(
     var sourceType: String,
     var code: String? = null,
@@ -94,8 +100,12 @@ data class RestSourceUsers(
 
 class TokenDTO(
     val accessToken: String?,
-    val expiresAt: Instant?,
-    val refreshToken: String?,
+    val expiresAt: Instant?
+)
+
+class UrlSignatureDTO(
+    val url: String,
+    val signedUrl: String?
 )
 
 data class Page(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
@@ -44,7 +44,7 @@ data class RestOauth1UserId(
 data class SignRequestParams(
     var url: String,
     var method: String,
-    val params: Map<String, String?>,
+    val parameters: Map<String, String?>,
 )
 
 data class RequestTokenPayload(
@@ -101,11 +101,6 @@ data class RestSourceUsers(
 data class TokenDTO(
     val accessToken: String?,
     val expiresAt: Instant?,
-)
-
-data class UrlSignatureDTO(
-    val url: String,
-    val signedUrl: String?,
 )
 
 data class Page(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
@@ -44,7 +44,7 @@ data class RestOauth1UserId(
 data class SignRequestParams(
     var url: String,
     var method: String,
-    val params: Map<String, String?>
+    val params: Map<String, String?>,
 )
 
 data class RequestTokenPayload(
@@ -98,14 +98,14 @@ data class RestSourceUsers(
     val users: List<RestSourceUserDTO>,
 )
 
-class TokenDTO(
+data class TokenDTO(
     val accessToken: String?,
-    val expiresAt: Instant?
+    val expiresAt: Instant?,
 )
 
-class UrlSignatureDTO(
+data class UrlSignatureDTO(
     val url: String,
-    val signedUrl: String?
+    val signedUrl: String?,
 )
 
 data class Page(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
@@ -95,6 +95,7 @@ data class RestSourceUsers(
 class TokenDTO(
     val accessToken: String?,
     val expiresAt: Instant?,
+    val refreshToken: String?,
 )
 
 data class Page(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
@@ -44,7 +44,7 @@ data class RestOauth1UserId(
 data class SignRequestParams(
     var url: String,
     var method: String,
-    val params: MutableMap<String, String?>
+    val params: Map<String, String?>
 )
 
 data class RequestTokenPayload(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepositoryImpl.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepositoryImpl.kt
@@ -26,6 +26,7 @@ import org.radarbase.jersey.exception.HttpNotFoundException
 import org.radarbase.jersey.hibernate.HibernateRepository
 import java.time.Duration
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import javax.inject.Provider
 import javax.persistence.EntityManager
 import javax.ws.rs.core.Context
@@ -150,7 +151,7 @@ class RestSourceUserRepositoryImpl(
         var queryString = """
                SELECT u
                FROM RestSourceUser u
-               WHERE u.endDate < CURRENT_TIMESTAMP - INTERVAL '14 days'
+               WHERE u.endDate < :prevFourteenDays
         """.trimIndent()
 
         if (sourceType != null) {
@@ -162,6 +163,7 @@ class RestSourceUserRepositoryImpl(
             if (sourceType != null) {
                 query.setParameter("sourceType", sourceType)
             }
+            query.setParameter("prevFourteenDays", Instant.now().minus(14, ChronoUnit.DAYS))
             query.resultList
         }
     }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
@@ -212,7 +212,7 @@ class RestSourceUserResource(
                 "user_unauthorized",
                 "Refresh token for ${user.userId ?: user.externalUserId} is no longer valid. Invalidated user authorization.")
         }
-        return TokenDTO(updatedUser.accessToken, updatedUser.expiresAt)
+        return TokenDTO(updatedUser.accessToken, updatedUser.expiresAt, user.refreshToken)
     }
 
     private fun validate(id: Long, user: RestSourceUserDTO, permission: Permission): RestSourceUser {

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
@@ -167,7 +167,7 @@ class RestSourceUserResource(
         val user = ensureUser(userId)
         auth.checkPermissionOnSubject(Permission.MEASUREMENT_CREATE, user.projectId, user.userId)
         return if (user.hasValidToken()) {
-            TokenDTO(user.accessToken, user.expiresAt)
+            TokenDTO(user.accessToken, user.expiresAt, user.refreshToken)
         } else {
             // refresh token if current token is already expired.
             refreshToken(userId, user)

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
@@ -187,12 +187,11 @@ class RestSourceUserResource(
     @POST
     @Path("{id}/token/sign")
     @NeedsPermission(Permission.Entity.MEASUREMENT, Permission.Operation.READ)
-    fun signUrl(@PathParam("id") userId: Long, payload: SignRequestParams): UrlSignatureDTO {
+    fun signRequest(@PathParam("id") userId: Long, payload: SignRequestParams): SignRequestParams {
         val user = ensureUser(userId)
         auth.checkPermissionOnSubject(Permission.MEASUREMENT_READ, user.projectId, user.userId)
-        val signedUrl = authorizationService.signUrl(user, payload.url, payload.method, payload.params)
 
-        return UrlSignatureDTO(payload.url, signedUrl)
+        return authorizationService.signRequest(user, payload)
     }
 
     @POST

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
@@ -19,6 +19,7 @@ package org.radarbase.authorizer.service
 import org.glassfish.hk2.api.IterableProvider
 import org.radarbase.authorizer.api.RequestTokenPayload
 import org.radarbase.authorizer.api.RestOauth2AccessToken
+import org.radarbase.authorizer.api.SignRequestParams
 import org.radarbase.authorizer.doa.entity.RestSourceUser
 import javax.ws.rs.core.Context
 
@@ -49,8 +50,8 @@ class DelegatedRestSourceAuthorizationService(
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String =
         delegate(sourceType).getAuthorizationEndpointWithParams(sourceType, callBackUrl)
 
-    override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String =
-        delegate(user.sourceType).signUrl(user, url, method, params)
+    override fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams =
+        delegate(user.sourceType).signRequest(user, payload)
 
     companion object {
         const val GARMIN_AUTH = "Garmin"

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
@@ -49,7 +49,7 @@ class DelegatedRestSourceAuthorizationService(
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String =
         delegate(sourceType).getAuthorizationEndpointWithParams(sourceType, callBackUrl)
 
-    override fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String =
+    override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String =
         delegate(user.sourceType).signUrl(user, url, method, params)
 
     companion object {

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
@@ -49,6 +49,9 @@ class DelegatedRestSourceAuthorizationService(
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String =
         delegate(sourceType).getAuthorizationEndpointWithParams(sourceType, callBackUrl)
 
+    override fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String =
+        delegate(user.sourceType).signUrl(user, url, method, params)
+
     companion object {
         const val GARMIN_AUTH = "Garmin"
         const val FITBIT_AUTH = "FitBit"

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
@@ -146,6 +146,15 @@ abstract class OAuth1RestSourceAuthorizationService(
             .build()
     }
 
+    override fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String {
+        val authConfig = configMap[user.sourceType]
+            ?: throw HttpBadRequestException("client-config-not-found",
+                "Cannot find client configurations for source-type ${user.sourceType}")
+        val tokens = RestOauth1AccessToken(user.accessToken!!, user.refreshToken)
+
+        return OauthSignature(url, params, method, authConfig.clientSecret, tokens.tokenSecret).getEncodedSignature()
+    }
+
     private fun getAuthParams(
         authConfig: RestSourceClient,
         accessToken: String?,

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
@@ -146,11 +146,13 @@ abstract class OAuth1RestSourceAuthorizationService(
             .build()
     }
 
-    override fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String {
+    override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String {
         val authConfig = configMap[user.sourceType]
             ?: throw HttpBadRequestException("client-config-not-found",
                 "Cannot find client configurations for source-type ${user.sourceType}")
-        val tokens = RestOauth1AccessToken(user.accessToken!!, user.refreshToken)
+        val accessToken = user.accessToken
+            ?: throw HttpBadRequestException("access-token-not-found", "No access token available for user")
+        val tokens = RestOauth1AccessToken(accessToken, user.refreshToken)
 
         return OauthSignature(url, params, method, authConfig.clientSecret, tokens.tokenSecret).getEncodedSignature()
     }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
@@ -152,9 +152,10 @@ abstract class OAuth1RestSourceAuthorizationService(
                 "Cannot find client configurations for source-type ${user.sourceType}")
         val accessToken = user.accessToken
             ?: throw HttpBadRequestException("access-token-not-found", "No access token available for user")
-        val tokens = RestOauth1AccessToken(accessToken, user.refreshToken)
+        val paramsWithToken = params.toMutableMap()
+        paramsWithToken.put(OAUTH_ACCESS_TOKEN, accessToken)
 
-        return OauthSignature(url, params, method, authConfig.clientSecret, tokens.tokenSecret).getEncodedSignature()
+        return OauthSignature(url, paramsWithToken.toSortedMap(), method, authConfig.clientSecret, user.refreshToken).getEncodedSignature()
     }
 
     private fun getAuthParams(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
@@ -22,10 +22,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import org.radarbase.authorizer.RestSourceClient
 import org.radarbase.authorizer.RestSourceClients
-import org.radarbase.authorizer.api.RequestTokenPayload
-import org.radarbase.authorizer.api.RestOauth1AccessToken
-import org.radarbase.authorizer.api.RestOauth2AccessToken
-import org.radarbase.authorizer.api.RestSourceUserMapper
+import org.radarbase.authorizer.api.*
 import org.radarbase.authorizer.doa.RestSourceUserRepository
 import org.radarbase.authorizer.doa.entity.RestSourceUser
 import org.radarbase.authorizer.util.OauthSignature
@@ -146,16 +143,23 @@ abstract class OAuth1RestSourceAuthorizationService(
             .build()
     }
 
-    override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String {
+    override fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams {
         val authConfig = configMap[user.sourceType]
             ?: throw HttpBadRequestException("client-config-not-found",
                 "Cannot find client configurations for source-type ${user.sourceType}")
+
         val accessToken = user.accessToken
             ?: throw HttpBadRequestException("access-token-not-found", "No access token available for user")
-        val paramsWithToken = params.toMutableMap()
-        paramsWithToken.put(OAUTH_ACCESS_TOKEN, accessToken)
+        val signedParams = payload.parameters.toMutableMap()
+        signedParams[OAUTH_ACCESS_TOKEN] = accessToken
+        signedParams[OAUTH_SIGNATURE_METHOD] = OAUTH_SIGNATURE_METHOD_VALUE
+        signedParams[OAUTH_SIGNATURE] = OauthSignature(payload.url,
+            signedParams.toSortedMap(),
+            payload.method,
+            authConfig.clientSecret,
+            user.refreshToken).getEncodedSignature()
 
-        return OauthSignature(url, paramsWithToken.toSortedMap(), method, authConfig.clientSecret, user.refreshToken).getEncodedSignature()
+        return SignRequestParams(payload.url, payload.method, signedParams)
     }
 
     private fun getAuthParams(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -103,10 +103,10 @@ class OAuth2RestSourceAuthorizationService(
     }
 
     override fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String {
-        return ""
+        throw HttpBadRequestException("", "Not available for auth type")
     }
 
-        private fun post(form: FormBody, sourceType: String): Request {
+    private fun post(form: FormBody, sourceType: String): Request {
         val authorizationConfig = configMap[sourceType]
             ?: throw HttpBadRequestException(
                 "client-config-not-found", "Cannot find client configurations for source-type $sourceType")

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -102,7 +102,7 @@ class OAuth2RestSourceAuthorizationService(
         throw HttpBadRequestException("", "Not available for auth type")
     }
 
-    override fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String {
+    override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String {
         throw HttpBadRequestException("", "Not available for auth type")
     }
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -102,7 +102,11 @@ class OAuth2RestSourceAuthorizationService(
         throw HttpBadRequestException("", "Not available for auth type")
     }
 
-    private fun post(form: FormBody, sourceType: String): Request {
+    override fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String {
+        return ""
+    }
+
+        private fun post(form: FormBody, sourceType: String): Request {
         val authorizationConfig = configMap[sourceType]
             ?: throw HttpBadRequestException(
                 "client-config-not-found", "Cannot find client configurations for source-type $sourceType")

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -24,6 +24,7 @@ import okhttp3.Request
 import org.radarbase.authorizer.RestSourceClients
 import org.radarbase.authorizer.api.RequestTokenPayload
 import org.radarbase.authorizer.api.RestOauth2AccessToken
+import org.radarbase.authorizer.api.SignRequestParams
 import org.radarbase.authorizer.doa.entity.RestSourceUser
 import org.radarbase.authorizer.util.StateStore
 import org.radarbase.jersey.exception.HttpBadGatewayException
@@ -102,7 +103,7 @@ class OAuth2RestSourceAuthorizationService(
         throw HttpBadRequestException("", "Not available for auth type")
     }
 
-    override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String {
+    override fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams {
         throw HttpBadRequestException("", "Not available for auth type")
     }
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
@@ -18,6 +18,7 @@ package org.radarbase.authorizer.service
 
 import org.radarbase.authorizer.api.RequestTokenPayload
 import org.radarbase.authorizer.api.RestOauth2AccessToken
+import org.radarbase.authorizer.api.SignRequestParams
 import org.radarbase.authorizer.doa.entity.RestSourceUser
 
 interface RestSourceAuthorizationService {
@@ -32,6 +33,6 @@ interface RestSourceAuthorizationService {
 
     fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String
 
-    fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String
+    fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams
 
 }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
@@ -32,6 +32,6 @@ interface RestSourceAuthorizationService {
 
     fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String
 
-    fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String
+    fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String
 
 }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
@@ -32,4 +32,6 @@ interface RestSourceAuthorizationService {
 
     fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String
 
+    fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String
+
 }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/util/OauthSignature.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/util/OauthSignature.kt
@@ -7,7 +7,7 @@ import javax.crypto.spec.SecretKeySpec
 
 data class OauthSignature(
     var endPoint: String,
-    var params: MutableMap<String, String?>,
+    var params: Map<String, String?>,
     var method: String,
     var clientSecret: String?,
     var tokenSecret: String?,


### PR DESCRIPTION
- Add endpoint for signing OAuth1 requests (instead of sending the tokenSecret/refresh token in the token endpoint)
- Parameters required are `SignRequestParams`: `{url: "", method: "", parameters: {}}`