### PR TITLE
Expose endpoint for revoking/deregistering access tokens

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
@@ -47,6 +47,10 @@ data class SignRequestParams(
     val parameters: Map<String, String?>,
 )
 
+data class DeregistrationsDTO(
+    val deregistrations: List<DeregistrationParams>
+)
+
 data class DeregistrationParams(
     val userId: String,
     val userAccessToken: String

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
@@ -47,6 +47,11 @@ data class SignRequestParams(
     val parameters: Map<String, String?>,
 )
 
+data class DeregistrationParams(
+    val userId: String,
+    val userAccessToken: String
+)
+
 data class RequestTokenPayload(
     var sourceType: String,
     var code: String? = null,

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepository.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepository.kt
@@ -31,5 +31,5 @@ interface RestSourceUserRepository {
     fun queryAllWithElapsedEndDate(sourceType: String? = null): List<RestSourceUser>
     fun delete(user: RestSourceUser)
     fun reset(user: RestSourceUser, startDate: Instant, endDate: Instant?): RestSourceUser
-    fun findByExternalId(externalId: String, sourceType: String): RestSourceUser
+    fun findByExternalId(externalId: String, sourceType: String): RestSourceUser?
 }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepository.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepository.kt
@@ -31,4 +31,5 @@ interface RestSourceUserRepository {
     fun queryAllWithElapsedEndDate(sourceType: String? = null): List<RestSourceUser>
     fun delete(user: RestSourceUser)
     fun reset(user: RestSourceUser, startDate: Instant, endDate: Instant?): RestSourceUser
+    fun findByExternalId(externalId: String, sourceType: String): RestSourceUser
 }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepositoryImpl.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepositoryImpl.kt
@@ -168,6 +168,24 @@ class RestSourceUserRepositoryImpl(
         }
     }
 
+    override fun findByExternalId(
+        externalId: String,
+        sourceType: String,
+    ): RestSourceUser {
+        var queryString = """
+               SELECT u
+               FROM RestSourceUser u
+               WHERE u.externalId < :externalId
+               AND u.sourceType = :sourceType
+        """.trimIndent()
+        return transact {
+            val query = createQuery(queryString, RestSourceUser::class.java)
+            query.setParameter("sourceType", sourceType)
+            query.setParameter("externalId", externalId)
+            query.singleResult
+        }
+    }
+
     override fun delete(user: RestSourceUser) = transact {
         remove(merge(user))
     }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepositoryImpl.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/doa/RestSourceUserRepositoryImpl.kt
@@ -171,19 +171,20 @@ class RestSourceUserRepositoryImpl(
     override fun findByExternalId(
         externalId: String,
         sourceType: String,
-    ): RestSourceUser {
+    ): RestSourceUser? {
         var queryString = """
                SELECT u
                FROM RestSourceUser u
-               WHERE u.externalId = :externalId
+               WHERE u.externalUserId = :externalId
                AND u.sourceType = :sourceType
         """.trimIndent()
-        return transact {
+        val result = transact {
             val query = createQuery(queryString, RestSourceUser::class.java)
             query.setParameter("sourceType", sourceType)
             query.setParameter("externalId", externalId)
-            query.singleResult
+            query.resultList
         }
+        return if (result.isEmpty()) null else result.get(0)
     }
 
     override fun delete(user: RestSourceUser) = transact {

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
@@ -136,7 +136,7 @@ class RestSourceUserResource(
     fun deleteUser(@PathParam("id") userId: Long): Response {
         val user = ensureUser(userId)
         auth.checkPermissionOnSubject(Permission.SUBJECT_UPDATE, user.projectId, user.userId)
-        authorizationService.revokeToken(user)
+        if (user.accessToken != null) authorizationService.revokeToken(user)
         userRepository.delete(user)
 
         return Response.noContent().header("user-removed", userId).build()

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
@@ -136,10 +136,9 @@ class RestSourceUserResource(
     fun deleteUser(@PathParam("id") userId: Long): Response {
         val user = ensureUser(userId)
         auth.checkPermissionOnSubject(Permission.SUBJECT_UPDATE, user.projectId, user.userId)
-        if (user.accessToken != null) {
-            authorizationService.revokeToken(user)
-        }
+        authorizationService.deleteUser(user)
         userRepository.delete(user)
+
         return Response.noContent().header("user-removed", userId).build()
     }
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/RestSourceUserResource.kt
@@ -136,7 +136,7 @@ class RestSourceUserResource(
     fun deleteUser(@PathParam("id") userId: Long): Response {
         val user = ensureUser(userId)
         auth.checkPermissionOnSubject(Permission.SUBJECT_UPDATE, user.projectId, user.userId)
-        authorizationService.deleteUser(user)
+        authorizationService.revokeToken(user)
         userRepository.delete(user)
 
         return Response.noContent().header("user-removed", userId).build()
@@ -190,17 +190,6 @@ class RestSourceUserResource(
         auth.checkPermissionOnSubject(Permission.MEASUREMENT_READ, user.projectId, user.userId)
 
         return authorizationService.signRequest(user, payload)
-    }
-
-    @POST
-    @Path("{id}/deregister")
-    @NeedsPermission(Permission.Entity.SUBJECT, Permission.Operation.UPDATE)
-    fun reportDeregistration(
-        @PathParam("id") userId: Long,
-    ): Response {
-        val user = ensureUser(userId)
-        authorizationService.deRegisterUser(user)
-        return Response.noContent().header("user-removed", userId).build()
     }
 
     private fun refreshToken(userId: Long, user: RestSourceUser): TokenDTO {

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
@@ -79,12 +79,12 @@ class SourceClientResource(
     }
 
     @DELETE
-    @Path("{type}/authorization/{serviceUserId}/token/{accessToken}")
+    @Path("{type}/authorization/{serviceUserId}/token")
     @NeedsPermission(Permission.Entity.MEASUREMENT, Permission.Operation.READ)
     fun deleteAuthorizationWithToken(
         @PathParam("serviceUserId") serviceUserId: String,
         @PathParam("sourceType") sourceType: String,
-        @PathParam("accessToken") accessToken: String?,
+        @QueryParam("accessToken") accessToken: String?,
     ): Boolean {
         val user = userRepository.findByExternalId(serviceUserId, sourceType)
         if (user == null) {
@@ -97,16 +97,6 @@ class SourceClientResource(
             auth.checkPermissionOnSubject(Permission.MEASUREMENT_READ, user.projectId, user.userId)
             return authorizationService.revokeToken(user)
         }
-    }
-
-    @DELETE
-    @Path("{type}/authorization/{serviceUserId}")
-    @NeedsPermission(Permission.Entity.MEASUREMENT, Permission.Operation.READ)
-    fun deleteAuthorizationWithoutToken(
-        @PathParam("serviceUserId") serviceUserId: String,
-        @PathParam("sourceType") sourceType: String,
-    ): Boolean {
-        return deleteAuthorizationWithToken(serviceUserId, sourceType, "")
     }
 
     @GET
@@ -124,7 +114,6 @@ class SourceClientResource(
 
     @POST
     @Path("{type}/deregister")
-    @NeedsPermission(Permission.Entity.SUBJECT, Permission.Operation.UPDATE)
     fun reportDeregistration(@PathParam("type") sourceType: String, params: DeregistrationParams): Response {
         val user = userRepository.findByExternalId(params.userId, sourceType)
         if (user != null) {

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
@@ -25,7 +25,6 @@ import org.radarbase.jersey.auth.Auth
 import org.radarbase.jersey.auth.Authenticated
 import org.radarbase.jersey.auth.NeedsPermission
 import org.radarbase.jersey.exception.HttpNotFoundException
-import org.radarbase.jersey.exception.HttpUnauthorizedException
 import org.radarcns.auth.authorization.Permission
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -120,13 +119,13 @@ class SourceClientResource(
 
     @POST
     @Path("{type}/deregister")
-    fun reportDeregistration(@PathParam("type") sourceType: String, params: DeregistrationParams): Response {
-        val user = userRepository.findByExternalId(params.userId, sourceType)
-        if (user != null) {
-            if (user.accessToken == params.userAccessToken)
+    fun reportDeregistration(@PathParam("type") sourceType: String, body: DeregistrationsDTO): Response {
+        body.deregistrations.forEach { it ->
+            val user = userRepository.findByExternalId(it.userId, sourceType)
+            if (user != null && user.accessToken == it.userAccessToken)
                 authorizationService.deregisterUser(user)
-            else throw HttpUnauthorizedException("token-not-valid", "Access token not valid")
         }
+
         return Response.ok().build()
     }
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
@@ -84,7 +84,7 @@ class SourceClientResource(
     @DELETE
     @Authenticated
     @Path("{type}/authorization/{serviceUserId}")
-    @NeedsPermission(Permission.Entity.MEASUREMENT, Permission.Operation.READ)
+    @NeedsPermission(Permission.Entity.SUBJECT, Permission.Operation.UPDATE)
     fun deleteAuthorizationWithToken(
         @PathParam("serviceUserId") serviceUserId: String,
         @PathParam("sourceType") sourceType: String,
@@ -97,7 +97,7 @@ class SourceClientResource(
                 return authorizationService.revokeToken(serviceUserId, sourceType, accessToken)
             } else throw HttpNotFoundException("user-not-found", "User and access token not valid")
         } else {
-            auth.checkPermissionOnSubject(Permission.MEASUREMENT_READ, user.projectId, user.userId)
+            auth.checkPermissionOnSubject(Permission.SUBJECT_UPDATE, user.projectId, user.userId)
             return authorizationService.revokeToken(user)
         }
     }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
@@ -107,8 +107,11 @@ class SourceClientResource(
         @PathParam("type") sourceType: String,
     ): RestSourceUserDTO {
         val user = userRepository.findByExternalId(serviceUserId, sourceType)
-        auth.checkPermissionOnSubject(Permission.MEASUREMENT_READ, user.projectId, user.userId)
-        return userMapper.fromEntity(user)
+        if (user != null) {
+            auth.checkPermissionOnSubject(Permission.MEASUREMENT_READ, user.projectId, user.userId)
+            return userMapper.fromEntity(user)
+        }
+        else throw HttpNotFoundException("user-not-found", "User with service user id not found.")
     }
 
     @POST

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
@@ -39,7 +39,6 @@ import javax.ws.rs.core.Response
 @Path("source-clients")
 @Produces(MediaType.APPLICATION_JSON)
 @Resource
-@Authenticated
 @Singleton
 class SourceClientResource(
     @Context private val restSourceClients: RestSourceClients,
@@ -54,15 +53,18 @@ class SourceClientResource(
     private val sharableClientDetails = clientMapper.fromSourceClientConfigs(restSourceClients.clients)
 
     @GET
+    @Authenticated
     @NeedsPermission(Permission.Entity.SOURCETYPE, Permission.Operation.READ)
     fun clients(): ShareableClientDetails = sharableClientDetails
 
     @GET
+    @Authenticated
     @Path("type")
     @NeedsPermission(Permission.Entity.SOURCETYPE, Permission.Operation.READ)
     fun types(): List<String> = sourceTypes
 
     @GET
+    @Authenticated
     @Path("{type}")
     @NeedsPermission(Permission.Entity.SOURCETYPE, Permission.Operation.READ)
     fun client(@PathParam("type") type: String): ShareableClientDetail {
@@ -73,6 +75,7 @@ class SourceClientResource(
     }
 
     @GET
+    @Authenticated
     @Path("{type}/auth-endpoint")
     @NeedsPermission(Permission.Entity.SOURCETYPE, Permission.Operation.READ)
     fun getAuthEndpoint(@PathParam("type") type: String, @QueryParam("callbackUrl") callbackUrl: String): String {
@@ -80,6 +83,7 @@ class SourceClientResource(
     }
 
     @DELETE
+    @Authenticated
     @Path("{type}/authorization/{serviceUserId}")
     @NeedsPermission(Permission.Entity.MEASUREMENT, Permission.Operation.READ)
     fun deleteAuthorizationWithToken(
@@ -100,6 +104,7 @@ class SourceClientResource(
     }
 
     @GET
+    @Authenticated
     @Path("{type}/authorization/{serviceUserId}")
     @NeedsPermission(Permission.Entity.MEASUREMENT, Permission.Operation.READ)
     fun getUserByServiceUserId(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
@@ -54,6 +54,9 @@ class DelegatedRestSourceAuthorizationService(
     override fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams =
         delegate(user.sourceType).signRequest(user, payload)
 
+    override fun deregisterUser(user: RestSourceUser) =
+        delegate(user.sourceType).deregisterUser(user)
+
     companion object {
         const val GARMIN_AUTH = "Garmin"
         const val FITBIT_AUTH = "FitBit"

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
@@ -19,6 +19,7 @@ package org.radarbase.authorizer.service
 import org.glassfish.hk2.api.IterableProvider
 import org.radarbase.authorizer.api.RequestTokenPayload
 import org.radarbase.authorizer.api.RestOauth2AccessToken
+import org.radarbase.authorizer.api.TokenDTO
 import org.radarbase.authorizer.doa.entity.RestSourceUser
 import javax.ws.rs.core.Context
 
@@ -42,6 +43,9 @@ class DelegatedRestSourceAuthorizationService(
 
     override fun revokeToken(user: RestSourceUser): Boolean =
         delegate(user.sourceType).revokeToken(user)
+
+    override fun revokeToken(externalId: String, sourceType: String, token: TokenDTO): Boolean =
+        delegate(sourceType).revokeToken(externalId, sourceType, token)
 
     override fun deRegisterUser(user: RestSourceUser): RestSourceUser =
         delegate(user.sourceType).deRegisterUser(user)

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
@@ -56,6 +56,9 @@ class DelegatedRestSourceAuthorizationService(
     override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String =
         delegate(user.sourceType).signUrl(user, url, method, params)
 
+    override fun deleteUser(user: RestSourceUser) =
+        delegate(user.sourceType).deleteUser(user)
+
     companion object {
         const val GARMIN_AUTH = "Garmin"
         const val FITBIT_AUTH = "FitBit"

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
@@ -47,7 +47,7 @@ class DelegatedRestSourceAuthorizationService(
     override fun revokeToken(externalId: String, sourceType: String, token: TokenDTO): Boolean =
         delegate(sourceType).revokeToken(externalId, sourceType, token)
 
-    override fun deRegisterUser(user: RestSourceUser): RestSourceUser =
+    override fun deRegisterUser(user: RestSourceUser) =
         delegate(user.sourceType).deRegisterUser(user)
 
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String =

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/DelegatedRestSourceAuthorizationService.kt
@@ -45,20 +45,14 @@ class DelegatedRestSourceAuthorizationService(
     override fun revokeToken(user: RestSourceUser): Boolean =
         delegate(user.sourceType).revokeToken(user)
 
-    override fun revokeToken(externalId: String, sourceType: String, token: TokenDTO): Boolean =
+    override fun revokeToken(externalId: String, sourceType: String, token: String): Boolean =
         delegate(sourceType).revokeToken(externalId, sourceType, token)
-
-    override fun deRegisterUser(user: RestSourceUser) =
-        delegate(user.sourceType).deRegisterUser(user)
 
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String =
         delegate(sourceType).getAuthorizationEndpointWithParams(sourceType, callBackUrl)
 
     override fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams =
         delegate(user.sourceType).signRequest(user, payload)
-
-    override fun deleteUser(user: RestSourceUser) =
-        delegate(user.sourceType).deleteUser(user)
 
     companion object {
         const val GARMIN_AUTH = "Garmin"

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminSourceAuthorizationService.kt
@@ -57,6 +57,10 @@ class GarminSourceAuthorizationService(
         }, 0, DEREGISTER_CHECK_PERIOD, TimeUnit.MILLISECONDS)
     }
 
+    override fun deregisterUser(user: RestSourceUser) {
+        userRepository.delete(user)
+    }
+
     override fun RestOauth1AccessToken.getExternalId(sourceType: String): String? {
         // Garmin does not provide the service/external id with the token payload, so an additional
         // request to pull the external id is needed.

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminSourceAuthorizationService.kt
@@ -25,6 +25,7 @@ import org.radarbase.authorizer.api.RestOauth1AccessToken
 import org.radarbase.authorizer.api.RestOauth1UserId
 import org.radarbase.authorizer.api.RestSourceUserMapper
 import org.radarbase.authorizer.doa.RestSourceUserRepository
+import org.radarbase.authorizer.doa.entity.RestSourceUser
 import org.radarbase.authorizer.service.DelegatedRestSourceAuthorizationService.Companion.GARMIN_AUTH
 import org.radarbase.jersey.exception.HttpBadGatewayException
 import org.slf4j.Logger
@@ -77,7 +78,7 @@ class GarminSourceAuthorizationService(
         requestScope.runInScope(Runnable {
             userRepository
                 .queryAllWithElapsedEndDate(GARMIN_AUTH)
-                .forEach { deRegisterUser(it) }
+                .forEach { revokeToken(it) }
         })
     }
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
@@ -146,11 +146,13 @@ abstract class OAuth1RestSourceAuthorizationService(
             .build()
     }
 
-    override fun signUrl(user: RestSourceUser, url: String, method: String, params: MutableMap<String, String?>): String {
+    override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String {
         val authConfig = configMap[user.sourceType]
             ?: throw HttpBadRequestException("client-config-not-found",
                 "Cannot find client configurations for source-type ${user.sourceType}")
-        val tokens = RestOauth1AccessToken(user.accessToken!!, user.refreshToken)
+        val accessToken = user.accessToken
+            ?: throw HttpBadRequestException("access-token-not-found", "No access token available for user")
+        val tokens = RestOauth1AccessToken(accessToken, user.refreshToken)
 
         return OauthSignature(url, params, method, authConfig.clientSecret, tokens.tokenSecret).getEncodedSignature()
     }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
@@ -152,9 +152,10 @@ abstract class OAuth1RestSourceAuthorizationService(
                 "Cannot find client configurations for source-type ${user.sourceType}")
         val accessToken = user.accessToken
             ?: throw HttpBadRequestException("access-token-not-found", "No access token available for user")
-        val tokens = RestOauth1AccessToken(accessToken, user.refreshToken)
+        val paramsWithToken = params.toMutableMap()
+        paramsWithToken.put(OAUTH_ACCESS_TOKEN, accessToken)
 
-        return OauthSignature(url, params, method, authConfig.clientSecret, tokens.tokenSecret).getEncodedSignature()
+        return OauthSignature(url, paramsWithToken.toSortedMap(), method, authConfig.clientSecret, user.refreshToken).getEncodedSignature()
     }
 
     private fun getAuthParams(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
@@ -110,6 +110,10 @@ abstract class OAuth1RestSourceAuthorizationService(
         return userRepository.delete(user)
     }
 
+    override fun deleteUser(user: RestSourceUser) {
+        logger.info("Deleting user...")
+    }
+
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String {
         logger.info("Getting auth endpoint..")
         val authConfig = configMap[sourceType]

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
@@ -86,15 +86,15 @@ abstract class OAuth1RestSourceAuthorizationService(
         }
     }
 
-    override fun revokeToken(externalId: String, sourceType: String, token: TokenDTO): Boolean {
+    override fun revokeToken(externalId: String, sourceType: String, token: String): Boolean {
         val authConfig = configMap[sourceType]
             ?: throw HttpBadRequestException("client-config-not-found",
                 "Cannot find client configurations for source-type ${sourceType}")
 
-        if(token.accessToken.isNullOrEmpty()) throw HttpBadRequestException("token-empty", "Token cannot be null or empty")
+        if(token.isNullOrEmpty()) throw HttpBadRequestException("token-empty", "Token cannot be null or empty")
         val req = createRequest("DELETE",
             authConfig.deregistrationEndpoint!!,
-            RestOauth1AccessToken(token.accessToken, ""),
+            RestOauth1AccessToken(token, ""),
             sourceType)
 
         return httpClient.newCall(req).execute().use { response ->
@@ -104,14 +104,6 @@ abstract class OAuth1RestSourceAuthorizationService(
                 else -> throw HttpBadGatewayException("Cannot connect to ${authConfig.deregistrationEndpoint}: HTTP status ${response.code}")
             }
         }
-    }
-
-    override fun deRegisterUser(user: RestSourceUser) {
-        return userRepository.delete(user)
-    }
-
-    override fun deleteUser(user: RestSourceUser) {
-        logger.info("Deleting user...")
     }
 
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String {

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth1RestSourceAuthorizationService.kt
@@ -90,7 +90,7 @@ abstract class OAuth1RestSourceAuthorizationService(
         val authConfig = configMap[sourceType]
             ?: throw HttpBadRequestException("client-config-not-found",
                 "Cannot find client configurations for source-type ${sourceType}")
-        
+
         if(token.accessToken.isNullOrEmpty()) throw HttpBadRequestException("token-empty", "Token cannot be null or empty")
         val req = createRequest("DELETE",
             authConfig.deregistrationEndpoint!!,
@@ -106,11 +106,8 @@ abstract class OAuth1RestSourceAuthorizationService(
         }
     }
 
-    override fun deRegisterUser(user: RestSourceUser): RestSourceUser {
-        revokeToken(user)
-        val userDTO = userMapper.fromEntity(user)
-        userDTO.isAuthorized = false
-        return userRepository.update(user, userDTO)
+    override fun deRegisterUser(user: RestSourceUser) {
+        return userRepository.delete(user)
     }
 
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String {

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -102,7 +102,7 @@ class OAuth2RestSourceAuthorizationService(
             .build().toString()
     }
 
-    override fun deRegisterUser(user: RestSourceUser): RestSourceUser =
+    override fun deRegisterUser(user: RestSourceUser) =
         throw HttpBadRequestException("", "Not available for auth type")
 
     override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String =

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -105,6 +105,11 @@ class OAuth2RestSourceAuthorizationService(
     override fun deRegisterUser(user: RestSourceUser) =
         throw HttpBadRequestException("", "Not available for auth type")
 
+    override fun deleteUser(user: RestSourceUser) {
+        logger.info("Deleting user...")
+        if (user.accessToken != null) revokeToken(user)
+    }
+
     override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String =
         throw HttpBadRequestException("", "Not available for auth type")
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -24,6 +24,7 @@ import okhttp3.Request
 import org.radarbase.authorizer.RestSourceClients
 import org.radarbase.authorizer.api.RequestTokenPayload
 import org.radarbase.authorizer.api.RestOauth2AccessToken
+import org.radarbase.authorizer.api.TokenDTO
 import org.radarbase.authorizer.doa.entity.RestSourceUser
 import org.radarbase.authorizer.util.StateStore
 import org.radarbase.jersey.exception.HttpBadGatewayException
@@ -83,6 +84,9 @@ class OAuth2RestSourceAuthorizationService(
         return httpClient.request(post(form, user.sourceType))
     }
 
+    override fun revokeToken(externalId: String, sourceType: String, token: TokenDTO): Boolean =
+        throw HttpBadRequestException("", "Not available for auth type")
+
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String {
         val authConfig = configMap[sourceType]
             ?: throw HttpBadRequestException("client-config-not-found",
@@ -98,13 +102,11 @@ class OAuth2RestSourceAuthorizationService(
             .build().toString()
     }
 
-    override fun deRegisterUser(user: RestSourceUser): RestSourceUser {
+    override fun deRegisterUser(user: RestSourceUser): RestSourceUser =
         throw HttpBadRequestException("", "Not available for auth type")
-    }
 
-    override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String {
+    override fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String =
         throw HttpBadRequestException("", "Not available for auth type")
-    }
 
     private fun post(form: FormBody, sourceType: String): Request {
         val authorizationConfig = configMap[sourceType]

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -85,7 +85,7 @@ class OAuth2RestSourceAuthorizationService(
         return httpClient.request(post(form, user.sourceType))
     }
 
-    override fun revokeToken(externalId: String, sourceType: String, token: TokenDTO): Boolean =
+    override fun revokeToken(externalId: String, sourceType: String, token: String): Boolean =
         throw HttpBadRequestException("", "Not available for auth type")
 
     override fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String {
@@ -103,15 +103,7 @@ class OAuth2RestSourceAuthorizationService(
             .build().toString()
     }
 
-    override fun deRegisterUser(user: RestSourceUser) =
-        throw HttpBadRequestException("", "Not available for auth type")
-
-    override fun deleteUser(user: RestSourceUser) {
-        logger.info("Deleting user...")
-        if (user.accessToken != null) revokeToken(user)
-    }
-
-    override fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams {
+    override fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams =
         throw HttpBadRequestException("", "Not available for auth type")
 
     private fun post(form: FormBody, sourceType: String): Request {

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -103,6 +103,9 @@ class OAuth2RestSourceAuthorizationService(
             .build().toString()
     }
 
+    override fun deregisterUser(user: RestSourceUser) =
+        throw HttpBadRequestException("", "Not available for auth type")
+
     override fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams =
         throw HttpBadRequestException("", "Not available for auth type")
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
@@ -37,4 +37,6 @@ interface RestSourceAuthorizationService {
 
     fun signUrl(user: RestSourceUser, url: String, method: String, params: Map<String, String?>): String
 
+    fun deleteUser(user: RestSourceUser)
+
 }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
@@ -31,7 +31,7 @@ interface RestSourceAuthorizationService {
 
     fun revokeToken(externalId: String, sourceType: String, token: TokenDTO): Boolean
 
-    fun deRegisterUser(user: RestSourceUser): RestSourceUser
+    fun deRegisterUser(user: RestSourceUser)
 
     fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
@@ -18,6 +18,7 @@ package org.radarbase.authorizer.service
 
 import org.radarbase.authorizer.api.RequestTokenPayload
 import org.radarbase.authorizer.api.RestOauth2AccessToken
+import org.radarbase.authorizer.api.TokenDTO
 import org.radarbase.authorizer.doa.entity.RestSourceUser
 
 interface RestSourceAuthorizationService {
@@ -27,6 +28,8 @@ interface RestSourceAuthorizationService {
     fun refreshToken(user: RestSourceUser): RestOauth2AccessToken?
 
     fun revokeToken(user: RestSourceUser): Boolean
+
+    fun revokeToken(externalId: String, sourceType: String, token: TokenDTO): Boolean
 
     fun deRegisterUser(user: RestSourceUser): RestSourceUser
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
@@ -30,14 +30,10 @@ interface RestSourceAuthorizationService {
 
     fun revokeToken(user: RestSourceUser): Boolean
 
-    fun revokeToken(externalId: String, sourceType: String, token: TokenDTO): Boolean
-
-    fun deRegisterUser(user: RestSourceUser)
+    fun revokeToken(externalId: String, sourceType: String, token: String): Boolean
 
     fun getAuthorizationEndpointWithParams(sourceType: String, callBackUrl: String): String
 
     fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams
-
-    fun deleteUser(user: RestSourceUser)
 
 }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceAuthorizationService.kt
@@ -36,4 +36,5 @@ interface RestSourceAuthorizationService {
 
     fun signRequest(user: RestSourceUser, payload: SignRequestParams): SignRequestParams
 
+    fun deregisterUser(user: RestSourceUser)
 }


### PR DESCRIPTION
- Exposes endpoint for revoking/deregistering access tokens needed for deregistering users in the PushEndpoint https://github.com/RADAR-base/RADAR-PushEndpoint/pull/11 at `DELETE source-clients/{type}/authorization/{serviceUserId}`
- Adds endpoint for getting user by serviceUserId at `GET source-clients/{type}/authorization/{serviceUserId}`
- Separate user deletion implementations for different auth types (so that Garmin auth can immediately delete while Fitbit auth can revoke first before deleting)
- Change Garmin deregistration endpoint to immediately delete the user 

Partially solves https://github.com/RADAR-base/RADAR-PushEndpoint/issues/12