### PR TITLE
Fix failing docker build

### DIFF
--- a/authorizer-app/package.json
+++ b/authorizer-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authorizer-app",
-  "version": "2.0",
+  "version": "2.0.0",
   "description": "Simple app to authorize to collect data from third party services ",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Fix the incorrect version format in `package.json` which is causing the docker build to fail because of missing dependencies

Version `2.0` already seems to be fixing the issues #101 and #103 which we were unable to pull because of the failing docker build