### PR TITLE
Fix OAuth signature encoding

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/util/OauthSignature.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/util/OauthSignature.kt
@@ -33,7 +33,7 @@ data class OauthSignature(
 
     companion object {
         private fun Map<String, String?>.toQueryFormat(): String = this
-            .map { (k, v) -> "$k=${v ?: ""}" }
+            .map { (k, v) -> "$k=${v ?: null}" }
             .joinToString("&")
     }
 }


### PR DESCRIPTION
- The encoded params for the signature needs the null values to be 'null' otherwise the access token request returns a `401` error
- This changes the null param values to be null instead of a blank string