### PR TITLE
Fix retrieving and storing of OAuth1 auth params

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/util/OauthSignature.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/util/OauthSignature.kt
@@ -33,7 +33,7 @@ data class OauthSignature(
 
     companion object {
         private fun Map<String, String?>.toQueryFormat(): String = this
-            .map { (k, v) -> "$k=${v ?: ""}" }
+            .map { (k, v) -> "$k=${v ?: null}" }
             .joinToString("&")
     }
 }

--- a/authorizer-app/src/app/admin/containers/user-dialog/user-dialog.component.ts
+++ b/authorizer-app/src/app/admin/containers/user-dialog/user-dialog.component.ts
@@ -183,6 +183,7 @@ export class UserDialogComponent {
       .subscribe({
         next: (resp) => {
           if (resp.authEndpointUrl) {
+            this.userService.storeUserAuthParams(resp.authEndpointUrl);
             window.location.href = resp.authEndpointUrl;
           } else if (resp.secret) {
             const baseUrl = this.getBaseUrl();

--- a/authorizer-app/src/app/admin/services/user.service.ts
+++ b/authorizer-app/src/app/admin/services/user.service.ts
@@ -10,13 +10,12 @@ import {
 } from '@app/admin/models/rest-source-user.model';
 
 import {environment} from '@environments/environment';
+import { StorageItem } from '@app/shared/enums/storage-item';
 
 @Injectable({
   providedIn: 'root'
 })
 export class UserService {
-  AUTH_ENDPOINT_PARAMS_STORAGE_KEY = 'auth_endpoint_params';
-
   constructor(private http: HttpClient) {}
 
   getUsersOfProject(projectId: string): Observable<RestSourceUsers> {
@@ -73,13 +72,17 @@ export class UserService {
   storeUserAuthParams(url: string) {
     const params = this.getJsonFromUrl(url);
     localStorage.setItem(
-      this.AUTH_ENDPOINT_PARAMS_STORAGE_KEY,
+      StorageItem.AUTH_ENDPOINT_PARAMS_STORAGE_KEY,
       JSON.stringify(params)
     );
   }
 
+  clearUserAuthParams() {
+    localStorage.removeItem(StorageItem.AUTH_ENDPOINT_PARAMS_STORAGE_KEY);
+  }
+
   getUserAuthParams() {
-    const params = localStorage.getItem(this.AUTH_ENDPOINT_PARAMS_STORAGE_KEY);
+    const params = localStorage.getItem(StorageItem.AUTH_ENDPOINT_PARAMS_STORAGE_KEY);
     return params ? JSON.parse(params) : {};
   }
 

--- a/authorizer-app/src/app/admin/services/user.service.ts
+++ b/authorizer-app/src/app/admin/services/user.service.ts
@@ -15,6 +15,7 @@ import {environment} from '@environments/environment';
   providedIn: 'root'
 })
 export class UserService {
+  AUTH_ENDPOINT_PARAMS_STORAGE_KEY = 'auth_endpoint_params';
 
   constructor(private http: HttpClient) {}
 
@@ -67,5 +68,29 @@ export class UserService {
       environment.backendBaseUrl + '/users/' + userId
     );
     return this.http.delete(url);
+  }
+
+  storeUserAuthParams(url: string) {
+    const params = this.getJsonFromUrl(url);
+    localStorage.setItem(
+      this.AUTH_ENDPOINT_PARAMS_STORAGE_KEY,
+      JSON.stringify(params)
+    );
+  }
+
+  getUserAuthParams() {
+    const params = localStorage.getItem(this.AUTH_ENDPOINT_PARAMS_STORAGE_KEY);
+    return params ? JSON.parse(params) : {};
+  }
+
+
+  getJsonFromUrl(url: string) {
+    const query = url.split('?')[1];
+    let result: any = {};
+    query.split('&').forEach(function(part) {
+      let item = part.split('=');
+      result[item[0]] = decodeURIComponent(item[1]);
+    });
+    return result;
   }
 }

--- a/authorizer-app/src/app/shared/containers/authorization-complete-page/authorization-complete-page.component.ts
+++ b/authorizer-app/src/app/shared/containers/authorization-complete-page/authorization-complete-page.component.ts
@@ -27,7 +27,22 @@ export class AuthorizationCompletePageComponent implements OnInit {
 
   ngOnInit(): void {
     this.isLoading = true;
-    const {state, oauth_token, oauth_verifier, oauth_token_secret, code} = this.activatedRoute.snapshot.queryParams;
+    const queryParams = this.activatedRoute.snapshot.queryParams;
+    const storedParams = this.service.getUserAuthParams();
+    const state = this.getOrDefault(queryParams.state, storedParams.state);
+    const oauth_token = this.getOrDefault(
+      queryParams.oauth_token,
+      storedParams.oauth_token
+    );
+    const oauth_verifier = this.getOrDefault(
+      queryParams.oauth_verifier,
+      storedParams.oauth_verifier
+    );
+    const oauth_token_secret = this.getOrDefault(
+      queryParams.oauth_token_secret,
+      storedParams.oauth_token_secret
+    );
+    const code = this.getOrDefault(queryParams.code, storedParams.code);
 
     let stateOrToken = state;
     if (!state) {
@@ -64,5 +79,9 @@ export class AuthorizationCompletePageComponent implements OnInit {
         this.error = error.error?.error_description || error.message || error;
       }
     });
+  }
+
+  getOrDefault(value: any, defaultValue: any) {
+    return value ? value : defaultValue;
   }
 }

--- a/authorizer-app/src/app/shared/containers/authorization-complete-page/authorization-complete-page.component.ts
+++ b/authorizer-app/src/app/shared/containers/authorization-complete-page/authorization-complete-page.component.ts
@@ -70,7 +70,7 @@ export class AuthorizationCompletePageComponent implements OnInit {
           this.router.navigate(
             [lastLocation.url || '/'],
             {queryParams: lastLocation.params}
-          ).finally();
+          ).finally(() => this.service.clearUserAuthParams());
         }
       },
       error: (error) => {

--- a/authorizer-app/src/app/shared/enums/storage-item.ts
+++ b/authorizer-app/src/app/shared/enums/storage-item.ts
@@ -1,4 +1,5 @@
 export enum StorageItem {
   AUTHORIZATION_TOKEN = 'authorizationToken',
-  LOCALE = 'locale'
+  LOCALE = 'locale',
+  AUTH_ENDPOINT_PARAMS_STORAGE_KEY = 'auth_endpoint_params'
 }


### PR DESCRIPTION
- The OAuth1 authentication needs the params: `oauth_token`, `oauth_token_secret`, and `oauth_token_verifier`, which is retrieved at different steps of the authentication process. These need to be stored so that they can be used at the final step which is requesting the access token. 
- Specifically, the `oauth_token_secret` was null (and this is needed as part of the signing key) so the signature was invalid.