### PR TITLE
Remove authentication from deregister endpoint

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/resources/SourceClientResource.kt
@@ -111,7 +111,6 @@ class SourceClientResource(
         body.deregistrations.forEach { deregistration ->
             val user = userRepository.findByExternalId(deregistration.userId, sourceType)
             if (user != null && user.accessToken == deregistration.userAccessToken) {
-                auth.checkPermissionOnSubject(Permission.SUBJECT_DELETE, user.projectId, user.userId)
                 authorizationService.deregisterUser(user)
             }
         }


### PR DESCRIPTION
- Since this request comes directly from garmin and does not have any radar auth info
- Closes #212 

----

Associated error logs

```
[2022-10-26 18:31:07,778] ERROR - [500] POST source-clients/Garmin/deregister (UnhandledExceptionMapper.kt:30)
org.glassfish.hk2.api.MultiException: A MultiException has 1 exceptions.  They are:
1. java.lang.IllegalStateException: Created null wrapper

	at org.jvnet.hk2.internal.SystemDescriptor.create(SystemDescriptor.java:473) ~[hk2-locator-3.0.2.jar:?]
	at org.glassfish.jersey.inject.hk2.RequestContext.findOrCreate(RequestContext.java:59) ~[jersey-hk2-3.0.4.jar:?]
	at org.jvnet.hk2.internal.MethodInterceptorImpl.internalInvoke(MethodInterceptorImpl.java:66) ~[hk2-locator-3.0.2.jar:?]
	at org.jvnet.hk2.internal.MethodInterceptorImpl.invoke(MethodInterceptorImpl.java:102) ~[hk2-locator-3.0.2.jar:?]
	at org.jvnet.hk2.internal.MethodInterceptorInvocationHandler.invoke(MethodInterceptorInvocationHandler.java:39) ~[hk2-locator-3.0.2.jar:?]
	at jdk.proxy3.$Proxy97.checkPermissionOnSubject(Unknown Source) ~[?:?]
	at org.radarbase.jersey.auth.Auth$DefaultImpls.checkPermissionOnSubject$default(Auth.kt:39) ~[radar-jersey-0.8.3.jar:0.8.3]
	at org.radarbase.authorizer.resources.SourceClientResource.reportDeregistration(SourceClientResource.kt:114) ~[authorizer-app-backend-4.0.1.jar:?]
	at jdk.internal.reflect.GeneratedMethodAccessor81.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$VoidOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:159) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:475) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:397) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:255) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248) ~[jersey-common-3.0.4.jar:?]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244) ~[jersey-common-3.0.4.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292) ~[jersey-common-3.0.4.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274) ~[jersey-common-3.0.4.jar:?]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244) ~[jersey-common-3.0.4.jar:?]
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265) ~[jersey-common-3.0.4.jar:?]
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:234) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:684) ~[jersey-server-3.0.4.jar:?]
	at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:356) ~[jersey-container-grizzly2-http-3.0.4.jar:?]
	at org.glassfish.grizzly.http.server.HttpHandler$1.run(HttpHandler.java:190) ~[grizzly-http-server-3.0.0.jar:3.0.0]
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:535) ~[grizzly-framework-3.0.0.jar:3.0.0]
	at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:515) ~[grizzly-framework-3.0.0.jar:3.0.0]
	at java.lang.Thread.run(Unknown Source) ~[?:?]
Caused by: java.lang.IllegalStateException: Created null wrapper
	at org.radarbase.jersey.auth.jwt.AuthFactory.get(AuthFactory.kt:23) ~[radar-jersey-0.8.3.jar:0.8.3]
	at org.radarbase.jersey.auth.jwt.AuthFactory.get(AuthFactory.kt:19) ~[radar-jersey-0.8.3.jar:0.8.3]
	at org.glassfish.jersey.inject.hk2.SupplierFactoryBridge.provide(SupplierFactoryBridge.java:76) ~[jersey-hk2-3.0.4.jar:?]
	at org.jvnet.hk2.internal.FactoryCreator.create(FactoryCreator.java:129) ~[hk2-locator-3.0.2.jar:?]
	at org.jvnet.hk2.internal.SystemDescriptor.create(SystemDescriptor.java:466) ~[hk2-locator-3.0.2.jar:?]
	... 32 more
```