### PR TITLE
Ignore checksum check for one change

### DIFF
--- a/authorizer-app-backend/src/main/resources/db/changelog/changes/20211008113000_add_registration_created_at.xml
+++ b/authorizer-app-backend/src/main/resources/db/changelog/changes/20211008113000_add_registration_created_at.xml
@@ -9,6 +9,7 @@
     <property name="now" value="current_timestamp" dbms="postgresql"/>
 
     <changeSet author="joris" id="Add registration creation date">
+        <validCheckSum>ANY</validCheckSum>
         <addColumn tableName="registration">
             <column name="created_at" type="datetime" defaultValueComputed="${now}">
                 <constraints nullable="false"/>


### PR DESCRIPTION
Currently, a change in checksum is preventing upgrade of the app. Based on discussion in #225 