### PR TITLE
Store auth params in authorization page 

### DIFF
--- a/authorizer-app/src/app/shared/containers/authorization-page/authorization-page.component.ts
+++ b/authorizer-app/src/app/shared/containers/authorization-page/authorization-page.component.ts
@@ -37,6 +37,7 @@ export class AuthorizationPageComponent implements OnInit {
           this.project = resp.project.id;
           this.authEndpointUrl = resp.authEndpointUrl;
           this.isLoading = false;
+          this.userService.storeUserAuthParams(resp.authEndpointUrl);
         }
       },
       error: (error) => {


### PR DESCRIPTION
- Authentication with OAuth1/Garmin fails because the token secret doesn't get stored when an auth URL is generated
- This fixes it by storing the token secret on the authorization page side

Solves #234 