### PR TITLE
4.1.1 snapshot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,9 +126,9 @@ jobs:
           # Use runtime labels from docker_meta_backend as well as fixed labels
           labels: |
             ${{ steps.docker_meta.outputs.labels }}
-            maintainer=Joris Borgdorff <joris@thehyve.nl>, Nivethika Mahasivam <nivethika@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>
+            maintainer=Nivethika Mahasivam <nivethika@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>, Bastiaan de Graaf <bastiaan@thehyve.nl>
             org.opencontainers.image.description=RADAR-base rest sources authorizer backend application
-            org.opencontainers.image.authors=Joris Borgdorff <joris@thehyve.nl>, Nivethika Mahasivam <nivethika@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>
+            org.opencontainers.image.authors=Nivethika Mahasivam <nivethika@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>, Bastiaan de Graaf <bastiaan@thehyve.nl>
             org.opencontainers.image.vendor=RADAR-base
             org.opencontainers.image.licenses=Apache-2.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,9 @@ jobs:
           # Use runtime labels from docker_meta_backend as well as fixed labels
           labels: |
             ${{ steps.docker_meta.outputs.labels }}
-            maintainer=Joris Borgdorff <joris@thehyve.nl>, Nivethika Mahasivam <nivethika@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>
+            maintainer=Nivethika Mahasivam <nivethika@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>, Bastiaan de Graaf <bastiaan@thehyve.nl>
             org.opencontainers.image.description=RADAR-base rest sources authorizer backend application
-            org.opencontainers.image.authors=Joris Borgdorff <joris@thehyve.nl>, Nivethika Mahasivam <nivethika@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>
+            org.opencontainers.image.authors=Nivethika Mahasivam <nivethika@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>, Bastiaan de Graaf <bastiaan@thehyve.nl>
             org.opencontainers.image.vendor=RADAR-base
             org.opencontainers.image.licenses=Apache-2.0
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,7 +7,7 @@ object Versions {
     const val kotlin = "1.9.10"
 
     const val radarCommons = "1.1.1"
-    const val radarJersey = "0.11.0"
+    const val radarJersey = "0.11.0-SNAPSHOT"
     const val postgresql = "42.6.0"
     const val ktor = "2.3.5"
     const val jedis = "5.0.2"


### PR DESCRIPTION
Bump radar jersey to 0.11.0-SNAPSHOT.

Update the maintainer and author lists in the github actions.