### PR TITLE
Configure dependabot to target dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "dev"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"


### PR DESCRIPTION
This is a PR to to run configure dependabot to run weekly and target the dev branch

I want to merge it to master to prevent unnecessary/incorrect PRs from dependabot, so we can incorporate the PRs into our regular release cycle.