### PR TITLE
Bump radar-jersey to SNAPSHOT version

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,21 +1,8 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
-    kotlin("jvm") version "1.9.10"
+    kotlin("jvm") version "1.9.22"
 }
 
 repositories {
     mavenCentral()
-}
-
-tasks.withType<JavaCompile> {
-    sourceCompatibility = "17"
-    targetCompatibility = "17"
-}
-
-tasks.withType<KotlinCompile> {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
-    }
+    mavenLocal()
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,7 +7,7 @@ object Versions {
     const val kotlin = "1.9.23"
 
     const val radarCommons = "1.1.2"
-    const val radarJersey = "0.11.1"
+    const val radarJersey = "0.11.2-SNAPSHOT"
     const val postgresql = "42.6.1"
     const val ktor = "2.3.11"
     const val jedis = "5.1.3"


### PR DESCRIPTION
Fix the problems with radar-jersey returning malformed `www-authenticate` headers.

See:
https://github.com/RADAR-base/radar-jersey/pull/88