### PR TITLE
Add support for Sentry monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 An application to get authorization from users to access their data through 3rd party APIs. Mainly supports OAuth2 Authorization code follow to request authorization and processes the returned authorization code to add new entries of users. It creates new users and adds properties compatible and required by the [RADAR REST and Fitbit connectors](https://github.com/RADAR-base/RADAR-REST-Connector).
 
+<!-- TOC -->
+* [RADAR-REST-Source-Auth](#radar-rest-source-auth)
+  * [Features supported](#features-supported)
+  * [APIs to be used by REST Source-Connectors](#apis-to-be-used-by-rest-source-connectors)
+  * [Installation](#installation)
+  * [Authorization](#authorization)
+    * [Registering OAuth Clients with ManagementPortal](#registering-oauth-clients-with-managementportal)
+  * [Sentry monitoring](#sentry-monitoring)
+  * [Migrating from 1.\*.\* version to 2.\*](#migrating-from-1-version-to-2)
+<!-- TOC -->
+
 ## Features supported
 
 1. It has one active entity where we store user properties.
@@ -59,6 +70,10 @@ scope: SOURCETYPE.READ,PROJECT.READ,SUBJECT.READ,SUBJECT.UPDATE,SUBJECT.CREATE
 callback-url: <advertised-url-of-rest-sources-authorizer-app>/login 
 # the callback-url should be resolvable and match with the environment variable of radar-rest-sources-authorizer -> AUTH_CALLBACK_URL in the docker-compose.yml file. 
 ```
+
+## Sentry monitoring
+
+See [here](authorizer-app-backend/README.md#sentry-monitoring) for instructions on how to enable Sentry monitoring.
 
 ## Migrating from 1.\*.\* version to 2.\*
 

--- a/authorizer-app-backend/README.md
+++ b/authorizer-app-backend/README.md
@@ -1,0 +1,19 @@
+# RADAR-REST-Source-Auth backend
+
+This is the backend for the RADAR REST Source Authorizer application.
+
+## Sentry monitoring
+
+To enable Sentry monitoring:
+1. Set a `SENTRY_DSN` environment variable that points to the desired Sentry DSN.
+2. (Optional) Set the `SENTRY_LOG_LEVEL` environment variable to control the minimum log level of events sent to Sentry.
+   The default log level for Sentry is `ERROR`. Possible values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.
+
+For further configuration of Sentry via environmental variables see [here](https://docs.sentry.io/platforms/java/configuration/#configuration-via-the-runtime-environment). For instance:
+
+```
+SENTRY_LOG_LEVEL: 'ERROR'
+SENTRY_DSN: 'https://000000000000.ingest.de.sentry.io/000000000000'
+SENTRY_ATTACHSTACKTRACE: true
+SENTRY_STACKTRACE_APP_PACKAGES: org.radarbase.authorizer
+```

--- a/authorizer-app-backend/docker-compose.yml
+++ b/authorizer-app-backend/docker-compose.yml
@@ -59,6 +59,10 @@ services:
 #      - REST_SOURCE_AUTHORIZER_MANAGEMENT_PORTAL_OAUTH_CLIENT_SECRET=secret
 #      - LOGGING_LEVEL_ORG_RADARBASE_AUTHORIZER=DEBUG
 #      - APP_SLEEP=10 # gives time for the database to boot before the application
+#      - SENTRY_LOG_LEVEL='ERROR'
+#      - SENTRY_DSN='https://000000000000.ingest.de.sentry.io/000000000000'
+#      - SENTRY_ATTACHSTACKTRACE=true
+#      - SENTRY_STACKTRACE_APP_PACKAGES=org.radarbase.authorizer
 #    volumes:
 #      - ./docker/etc/rest-source-authorizer/:/app-includes/
 #    healthcheck:

--- a/authorizer-app-backend/src/main/resources/log4j2.xml
+++ b/authorizer-app-backend/src/main/resources/log4j2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ /*
+  ~  *  Copyright 2024 The Hyve
+  ~  *
+  ~  *  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  *  you may not use this file except in compliance with the License.
+  ~  *  You may obtain a copy of the License at
+  ~  *
+  ~  *    http://www.apache.org/licenses/LICENSE-2.0
+  ~  *
+  ~  *  Unless required by applicable law or agreed to in writing, software
+  ~  *  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  *  See the License for the specific language governing permissions and
+  ~  *  limitations under the License.
+  ~  */
+  -->
+
+<configuration status="INFO">
+    <appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout
+                    pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+            />
+        </Console>
+        <!-- For Sentry to work the DSN must be set via SENTRY_DSN environment variable
+             When SENTRY_DSN is empty string, the Sentry SDK is disabled -->
+        <Sentry name="Sentry" debug="false"/>
+    </appenders>
+
+    <loggers>
+        <root level="${env:LOG4J_LOG_LEVEL:-ERROR}">
+            <appender-ref ref="Console" />
+            <!-- Note that the Sentry logging threshold is at WARN level by default -->
+            <appender-ref ref="Sentry" level="${env:SENTRY_LOG_LEVEL:-ERROR}" />
+        </root>
+    </loggers>
+</configuration>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,5 +20,6 @@ subprojects {
 
     radarKotlin {
         log4j2Version.set(rootProject.libs.versions.log4j2)
+        sentryEnabled.set(true)
     }
 }


### PR DESCRIPTION
Description: This PR will add option to monitor the application with Sentry. Sentry monitoring will be enabled by the following:

1. Set a `SENTRY_DSN` environment variable that points to the desired Sentry DSN.
2. (Optional) Set the `SENTRY_LOG_LEVEL` environment variable to control the minimum log level of events sent to Sentry.
   The default log level for Sentry is `ERROR`. Possible values are `TRACE`, `DEBUG`, `INFO`, `WARN`, and `ERROR`.

The docs were updated with these instructions.