### PR TITLE
Allow setting URLs for REST clients via env vars

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
@@ -18,4 +18,6 @@ data class RestSourceClient(
     fun withEnv(): RestSourceClient = this
         .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_ID") { copy(clientId = it) }
         .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_SECRET") { copy(clientSecret = it) }
+        .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_AUTH_URL") { copy(authorizationEndpoint = it) }
+        .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_TOKEN_URL") { copy(tokenEndpoint = it) }
 }

--- a/authorizer-app/package.json
+++ b/authorizer-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authorizer-app",
-  "version": "4.4.5",
+  "version": "4.4.6",
   "description": "Simple app to authorize to collect data from third party services ",
   "repository": {
     "type": "git",

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "4.4.5"
+    const val project = "4.4.6"
 
     const val java = 17
 


### PR DESCRIPTION
# Problem
For implementing e2e-tests we would like to configure alternative URLs for authentication and token retrieval for REST clients such as Fitbit.

# Solution
This PR will allow overriding the URLs for authentication and token retrieval via environmental variables.