### PR TITLE
Up radar-jersey version and prepare for release 4.4.5

### DIFF
--- a/authorizer-app/package.json
+++ b/authorizer-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authorizer-app",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "description": "Simple app to authorize to collect data from third party services ",
   "repository": {
     "type": "git",

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -7,7 +7,7 @@ object Versions {
     const val kotlin = "1.9.23"
 
     const val radarCommons = "1.1.2"
-    const val radarJersey = "0.11.2"
+    const val radarJersey = "0.12.0"
     const val postgresql = "42.6.1"
     const val ktor = "2.3.11"
     const val jedis = "5.1.3"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "4.4.4"
+    const val project = "4.4.5"
 
     const val java = 17
 


### PR DESCRIPTION
This PR will up the radar-jersey version in order to fix a bug where projects with spaces in the name resulted in an error. while retrieving subjects from the backend.