### PR TITLE
Add support for additional params in auth url

### DIFF
--- a/authorizer-app/src/app/admin/services/user.service.ts
+++ b/authorizer-app/src/app/admin/services/user.service.ts
@@ -70,6 +70,26 @@ export class UserService {
     return this.http.delete(url);
   }
 
+  storeAuthorizationToken(token: string) {
+    localStorage.setItem(StorageItem.AUTHORIZATION_TOKEN, token);
+  }
+
+  getAuthorizationToken() {
+    return localStorage.getItem(StorageItem.AUTHORIZATION_TOKEN);
+  }
+
+  storeReturnUrl(url: string) {
+    localStorage.setItem(StorageItem.EXTERNAL_RETURN_URL, url);
+  }
+
+  getReturnUrl() {
+    return localStorage.getItem(StorageItem.EXTERNAL_RETURN_URL);
+  }
+
+  clearReturnUrl() {
+    localStorage.removeItem(StorageItem.EXTERNAL_RETURN_URL);
+  }
+
   storeUserAuthParams(url: string) {
     const params = this.getJsonFromUrl(url);
     localStorage.setItem(
@@ -86,7 +106,6 @@ export class UserService {
     const params = localStorage.getItem(StorageItem.AUTH_ENDPOINT_PARAMS_STORAGE_KEY);
     return params ? JSON.parse(params) : {};
   }
-
 
   getJsonFromUrl(url: string) {
     const query = url.split('?')[1];

--- a/authorizer-app/src/app/shared/containers/authorization-complete-page/authorization-complete-page.component.ts
+++ b/authorizer-app/src/app/shared/containers/authorization-complete-page/authorization-complete-page.component.ts
@@ -29,59 +29,65 @@ export class AuthorizationCompletePageComponent implements OnInit {
     this.isLoading = true;
     const queryParams = this.activatedRoute.snapshot.queryParams;
     const storedParams = this.service.getUserAuthParams();
-    const state = this.getOrDefault(queryParams.state, storedParams.state);
-    const oauth_token = this.getOrDefault(
-      queryParams.oauth_token,
-      storedParams.oauth_token
-    );
-    const oauth_verifier = this.getOrDefault(
-      queryParams.oauth_verifier,
-      storedParams.oauth_verifier
-    );
-    const oauth_token_secret = this.getOrDefault(
-      queryParams.oauth_token_secret,
-      storedParams.oauth_token_secret
-    );
-    const code = this.getOrDefault(queryParams.code, storedParams.code);
+    const stateOrToken = this.getStateOrToken(queryParams, storedParams);
 
-    let stateOrToken = state;
-    if (!state) {
-      stateOrToken = localStorage.getItem(SharedStorageItem.AUTHORIZATION_TOKEN);
-    }
-    if(!stateOrToken){
-      this.error = 'SHARED.AUTHORIZATION_COMPLETE_PAGE.ERROR.badUrl';
-      this.isLoading = false;
+    if (!stateOrToken) {
+      this.handleError('SHARED.AUTHORIZATION_COMPLETE_PAGE.ERROR.badUrl');
       return;
     }
-    const authorizeRequest = {
-      code,
-      oauth_token,
-      oauth_verifier,
-      oauth_token_secret
-    };
+
+    const authorizeRequest = this.buildAuthorizeRequest(queryParams, storedParams);
     this.service.authorizeUser(authorizeRequest, stateOrToken).subscribe({
-      next: (resp) => {
-        this.sourceType = resp.sourceType;
-        this.project = resp.project.id;
-        if (resp.persistent) {
-          this.isLoading = false;
-        } else {
-          const lastLocation = JSON.parse(localStorage.getItem(StorageItem.LAST_LOCATION) || '{}');
-          this.router.navigate(
-            [lastLocation.url || '/'],
-            {queryParams: lastLocation.params}
-          ).finally(() => this.service.clearUserAuthParams());
-        }
-      },
-      error: (error) => {
-        this.isLoading = false;
-        // TODO translate errors
-        this.error = error.error?.error_description || error.message || error;
-      }
+      next: (resp) => this.handleSuccessResponse(resp),
+      error: (error) => this.handleError(error.error?.error_description || error.message || error)
     });
   }
 
-  getOrDefault(value: any, defaultValue: any) {
-    return value ? value : defaultValue;
+  private getStateOrToken(queryParams: any, storedParams: any): string | null {
+    return (
+      this.getOrDefault(queryParams.state, storedParams.state) ||
+      localStorage.getItem(SharedStorageItem.AUTHORIZATION_TOKEN)
+    );
+  }
+
+  private buildAuthorizeRequest(queryParams: any, storedParams: any): any {
+    return {
+      code: this.getOrDefault(queryParams.code, storedParams.code),
+      oauth_token: this.getOrDefault(queryParams.oauth_token, storedParams.oauth_token),
+      oauth_verifier: this.getOrDefault(queryParams.oauth_verifier, storedParams.oauth_verifier),
+      oauth_token_secret: this.getOrDefault(queryParams.oauth_token_secret, storedParams.oauth_token_secret)
+    };
+  }
+
+  private handleSuccessResponse(resp: any): void {
+    this.sourceType = resp.sourceType;
+    this.project = resp.project.id;
+
+    this.redirectToExternalUrl();
+
+    if (resp.persistent) {
+      this.isLoading = false;
+      return;
+    }
+    const lastLocation = JSON.parse(localStorage.getItem(StorageItem.LAST_LOCATION) || '{}');
+    this.router.navigate([lastLocation.url || '/'], { queryParams: lastLocation.params })
+      .finally(() => this.service.clearUserAuthParams());
+  }
+
+  private redirectToExternalUrl(): void {
+    const externalUrl = this.service.getReturnUrl();
+    if (externalUrl) {
+      this.service.clearReturnUrl();
+      window.location.href = externalUrl;
+    }
+  }
+
+  private handleError(message: string): void {
+    this.error = message;
+    this.isLoading = false;
+  }
+
+  private getOrDefault(value: any, defaultValue: any): any {
+    return value ?? defaultValue;
   }
 }

--- a/authorizer-app/src/app/shared/containers/authorization-complete-page/authorization-complete-page.component.ts
+++ b/authorizer-app/src/app/shared/containers/authorization-complete-page/authorization-complete-page.component.ts
@@ -1,10 +1,10 @@
-import {Component, OnInit} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 
-import {UserService} from "@app/admin/services/user.service";
-import {AuthService} from "@app/auth/services/auth.service";
-import {StorageItem as SharedStorageItem} from "@app/shared/enums/storage-item";
-import {StorageItem} from "@app/auth/enums/storage-item";
+import { UserService } from "@app/admin/services/user.service";
+import { AuthService } from "@app/auth/services/auth.service";
+import { StorageItem as SharedStorageItem } from "@app/shared/enums/storage-item";
+import { StorageItem } from "@app/auth/enums/storage-item";
 
 @Component({
   selector: 'app-authorization-complete-page',
@@ -23,7 +23,7 @@ export class AuthorizationCompletePageComponent implements OnInit {
     private router: Router,
     private service: UserService,
     public authService: AuthService
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.isLoading = true;
@@ -78,13 +78,22 @@ export class AuthorizationCompletePageComponent implements OnInit {
     const externalUrl = this.service.getReturnUrl();
     if (externalUrl) {
       this.service.clearReturnUrl();
-      window.location.href = externalUrl;
+      let redirectUrl = externalUrl;
+
+      if (this.error) {
+        const encodedError = encodeURIComponent(this.error);
+        const separator = externalUrl.includes('?') ? '&' : '?';
+        redirectUrl += `${separator}error=${encodedError}`;
+      }
+
+      window.location.href = redirectUrl;
     }
   }
 
   private handleError(message: string): void {
     this.error = message;
     this.isLoading = false;
+    this.redirectToExternalUrl();
   }
 
   private getOrDefault(value: any, defaultValue: any): any {

--- a/authorizer-app/src/app/shared/containers/authorization-page/authorization-page.component.ts
+++ b/authorizer-app/src/app/shared/containers/authorization-page/authorization-page.component.ts
@@ -1,8 +1,7 @@
-import {Component, OnInit} from '@angular/core';
-import {ActivatedRoute} from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
-import {UserService} from "@app/admin/services/user.service";
-import {StorageItem} from "@app/shared/enums/storage-item";
+import { UserService } from "@app/admin/services/user.service";
 
 @Component({
   selector: 'app-authorization-page',
@@ -20,18 +19,18 @@ export class AuthorizationPageComponent implements OnInit {
   constructor(
     private activatedRoute: ActivatedRoute,
     private userService: UserService,
-  ) {}
+  ) { }
 
   ngOnInit(): void {
-    const {token, secret, redirect, return_to} = this.activatedRoute.snapshot.queryParams;
-    if(!token || !secret){
+    const { token, secret, redirect, return_to } = this.activatedRoute.snapshot.queryParams;
+    if (!token || !secret) {
       this.error = 'SHARED.AUTHORIZATION_PAGE.ERROR.badUrl';
       this.isLoading = false;
       return;
     }
     this.userService.storeAuthorizationToken(token);
     this.userService.storeReturnUrl(return_to);
-    this.userService.getAuthEndpointUrl({secret}, token).subscribe({
+    this.userService.getAuthEndpointUrl({ secret }, token).subscribe({
       next: (resp) => {
         if (resp.authEndpointUrl) {
           this.sourceType = resp.sourceType;
@@ -46,22 +45,39 @@ export class AuthorizationPageComponent implements OnInit {
       },
       error: (error) => {
         this.isLoading = false;
-        if(error.status === 400 && error.error.error === 'registration_not_found'){
+        if (error.status === 400 && error.error.error === 'registration_not_found') {
           this.error = 'SHARED.AUTHORIZATION_PAGE.ERROR.registrationNotFound';
           return;
         }
-        if(error.status === 400 && error.error.error === 'bad_secret'){
+        if (error.status === 400 && error.error.error === 'bad_secret') {
           this.error = 'SHARED.AUTHORIZATION_PAGE.ERROR.badSecret';
           return;
         }
         this.error = error.error?.error_description || error.message || error;
+        this.redirectToExternalUrl();
       },
     });
   }
 
   authorize(): void {
-    if(this.authEndpointUrl) {
+    if (this.authEndpointUrl) {
       window.location.href = this.authEndpointUrl;
+    }
+  }
+
+  private redirectToExternalUrl(): void {
+    const externalUrl = this.userService.getReturnUrl();
+    if (externalUrl) {
+      this.userService.clearReturnUrl();
+      let redirectUrl = externalUrl;
+
+      if (this.error) {
+        const encodedError = encodeURIComponent(this.error);
+        const separator = externalUrl.includes('?') ? '&' : '?';
+        redirectUrl += `${separator}error=${encodedError}`;
+      }
+
+      window.location.href = redirectUrl;
     }
   }
 }

--- a/authorizer-app/src/app/shared/containers/authorization-page/authorization-page.component.ts
+++ b/authorizer-app/src/app/shared/containers/authorization-page/authorization-page.component.ts
@@ -23,21 +23,25 @@ export class AuthorizationPageComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const {token, secret} = this.activatedRoute.snapshot.queryParams;
+    const {token, secret, redirect, return_to} = this.activatedRoute.snapshot.queryParams;
     if(!token || !secret){
       this.error = 'SHARED.AUTHORIZATION_PAGE.ERROR.badUrl';
       this.isLoading = false;
       return;
     }
-    localStorage.setItem(StorageItem.AUTHORIZATION_TOKEN, token);
+    this.userService.storeAuthorizationToken(token);
+    this.userService.storeReturnUrl(return_to);
     this.userService.getAuthEndpointUrl({secret}, token).subscribe({
       next: (resp) => {
         if (resp.authEndpointUrl) {
           this.sourceType = resp.sourceType;
           this.project = resp.project.id;
           this.authEndpointUrl = resp.authEndpointUrl;
-          this.isLoading = false;
           this.userService.storeUserAuthParams(resp.authEndpointUrl);
+          if (redirect) {
+            this.authorize();
+          }
+          this.isLoading = false;
         }
       },
       error: (error) => {

--- a/authorizer-app/src/app/shared/enums/storage-item.ts
+++ b/authorizer-app/src/app/shared/enums/storage-item.ts
@@ -1,5 +1,6 @@
 export enum StorageItem {
   AUTHORIZATION_TOKEN = 'authorizationToken',
   LOCALE = 'locale',
-  AUTH_ENDPOINT_PARAMS_STORAGE_KEY = 'auth_endpoint_params'
+  AUTH_ENDPOINT_PARAMS_STORAGE_KEY = 'auth_endpoint_params',
+  EXTERNAL_RETURN_URL = 'externalReturnUrl',
 }


### PR DESCRIPTION
- Add support for additional params in the `AuthorizationPage` to allow redirecting directly to Fitbit auth and allow redirecting to a custom URL after authorization is complete (using `redirect=true` and `redirect_uri=URL-HERE`
- If there is an error, it will redirect with `?error=message` param
- Also added improvements to the `AuthorzationCompletePage`
- Needed by the SEP portal (since user will self authorise and need to be redirected back to the SEP portal)