### PR TITLE
open telemetry update

### DIFF
--- a/authorizer-app/package.json
+++ b/authorizer-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authorizer-app",
-  "version": "4.4.9",
+  "version": "4.5.0",
   "description": "Simple app to authorize to collect data from third party services ",
   "repository": {
     "type": "git",

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,12 +1,12 @@
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "4.4.9"
+    const val project = "4.5.0"
 
     const val java = 17
 
     const val kotlin = "1.9.23"
 
-    const val radarCommons = "1.1.3"
+    const val radarCommons = "1.2.2"
     const val radarJersey = "0.12.2"
     const val postgresql = "42.6.1"
     const val ktor = "2.3.11"


### PR DESCRIPTION
Description: Update radar commons to enable open telemetry

This pr updates radar commons to version 1.2.2 which enables open telemetry.
RADAR-Rest-Source-Auth has been upped to version 4.5.0 from 4.4.9.
