### PR TITLE
Feat/oura nullable email

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
@@ -56,7 +56,7 @@ data class OuraAuthUserId(
     val weight: Float? = null,
     val height: Float? = null,
     val biological_sex: String? = null,
-    val email: String,
+    val email: String? = null,
     @SerialName("id") val userId: String,
 )
 


### PR DESCRIPTION
Makes the email field on OuraAuthUserId nullable.

It seems like the response from Oura sometimes doesn't have an email set, resulting in a serialisation error when trying to fetch/register the Oura user.