### PR TITLE
Re-added the Garmin OAuth 1 authorization service

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/api/ApiDeclarations.kt
@@ -45,6 +45,12 @@ data class RestOauth1AccessToken(
 )
 
 @Serializable
+data class RestOauth1UserId(
+    @SerialName("userId")
+    val userId: String,
+)
+
+@Serializable
 data class RestOauth2UserId(
     @SerialName("userId")
     val userId: String,

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
@@ -15,10 +15,11 @@ data class RestSourceClient(
     val scope: String? = null,
     val state: String? = null,
     val usesPkce: Boolean = false,
+    val oauthVersion: String = "oauth2",
 ) {
-    fun withEnv(): RestSourceClient = this
-        .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_ID") { copy(clientId = it) }
-        .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_SECRET") { copy(clientSecret = it) }
-        .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_AUTH_URL") { copy(authorizationEndpoint = it) }
-        .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_TOKEN_URL") { copy(tokenEndpoint = it) }
+    fun withEnv(): RestSourceClient =
+        this.copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_ID") { copy(clientId = it) }
+            .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_SECRET") { copy(clientSecret = it) }
+            .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_AUTH_URL") { copy(authorizationEndpoint = it) }
+            .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_TOKEN_URL") { copy(tokenEndpoint = it) }
 }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
@@ -116,6 +116,7 @@ class AuthorizerResourceEnhancer(
             bind(GarminOauth1AuthorizationService::class.java)
                 .to(RestSourceAuthorizationService::class.java)
                 .named(GARMIN_AUTH)
+                .`in`(Singleton::class.java)
         }
 
         bind(GarminOAuth2AuthorizationService::class.java)

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
@@ -29,7 +29,8 @@ import org.radarbase.authorizer.service.DelegatedRestSourceAuthorizationService
 import org.radarbase.authorizer.service.DelegatedRestSourceAuthorizationService.Companion.FITBIT_AUTH
 import org.radarbase.authorizer.service.DelegatedRestSourceAuthorizationService.Companion.GARMIN_AUTH
 import org.radarbase.authorizer.service.DelegatedRestSourceAuthorizationService.Companion.OURA_AUTH
-import org.radarbase.authorizer.service.GarminAuthorizationService
+import org.radarbase.authorizer.service.GarminOAuth2AuthorizationService
+import org.radarbase.authorizer.service.GarminOauth1AuthorizationService
 import org.radarbase.authorizer.service.OAuth2RestSourceAuthorizationService
 import org.radarbase.authorizer.service.OuraAuthorizationService
 import org.radarbase.authorizer.service.RegistrationService
@@ -50,6 +51,10 @@ class AuthorizerResourceEnhancer(
                 requireNotNull(it.clientSecret) { "Client secret of ${it.sourceType} is missing" }
             },
     )
+
+    private val sourceTypeOauthMap: Map<String, String> = config.restSourceClients.associate {
+        it.sourceType to it.oauthVersion.lowercase()
+    }
 
     override val classes: Array<Class<*>>
         get() = listOfNotNull(
@@ -102,7 +107,18 @@ class AuthorizerResourceEnhancer(
         bind(DelegatedRestSourceAuthorizationService::class.java)
             .to(RestSourceAuthorizationService::class.java)
 
-        bind(GarminAuthorizationService::class.java)
+        if (sourceTypeOauthMap[GARMIN_AUTH].equals("oauth2", ignoreCase = true)) {
+            bind(GarminOAuth2AuthorizationService::class.java)
+                .to(RestSourceAuthorizationService::class.java)
+                .named(GARMIN_AUTH)
+                .`in`(Singleton::class.java)
+        } else {
+            bind(GarminOauth1AuthorizationService::class.java)
+                .to(RestSourceAuthorizationService::class.java)
+                .named(GARMIN_AUTH)
+        }
+
+        bind(GarminOAuth2AuthorizationService::class.java)
             .to(RestSourceAuthorizationService::class.java)
             .named(GARMIN_AUTH)
             .`in`(Singleton::class.java)

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminOAuth1AuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminOAuth1AuthorizationService.kt
@@ -1,0 +1,91 @@
+/*
+ *  Copyright 2020 The Hyve
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.radarbase.authorizer.service
+
+import io.ktor.client.call.body
+import io.ktor.client.statement.request
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import jakarta.ws.rs.core.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.glassfish.jersey.server.BackgroundScheduler
+import org.radarbase.authorizer.api.RestOauth1AccessToken
+import org.radarbase.authorizer.api.RestOauth1UserId
+import org.radarbase.authorizer.config.AuthorizerConfig
+import org.radarbase.authorizer.doa.RestSourceUserRepository
+import org.radarbase.authorizer.doa.entity.RestSourceUser
+import org.radarbase.authorizer.service.DelegatedRestSourceAuthorizationService.Companion.GARMIN_AUTH
+import org.radarbase.jersey.exception.HttpBadGatewayException
+import org.radarbase.jersey.service.AsyncCoroutineService
+import org.radarbase.kotlin.coroutines.forkJoin
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+class GarminOauth1AuthorizationService(
+    @param:Context private val clientService: RestSourceClientService,
+    @param:Context private val userRepository: RestSourceUserRepository,
+    @param:Context private val asyncService: AsyncCoroutineService,
+    @param:Context
+    @param:BackgroundScheduler
+    private val scheduler: ScheduledExecutorService,
+    @param:Context private val config: AuthorizerConfig,
+) : OAuth1RestSourceAuthorizationService(
+    clientService,
+    userRepository,
+    config,
+) {
+    init {
+        // This schedules a task that periodically checks users with elapsed end dates and deregisters them.
+        scheduler.scheduleAtFixedRate(
+            ::checkForUsersWithElapsedEndDateAndDeregister,
+            0,
+            DEREGISTER_CHECK_PERIOD,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    override suspend fun deregisterUser(user: RestSourceUser) {
+        userRepository.delete(user)
+    }
+
+    override suspend fun RestOauth1AccessToken.getExternalId(sourceType: String): String = withContext(Dispatchers.IO) {
+        // Garmin does not provide the service/external id with the token payload, so an additional
+        // request to pull the external id is needed.
+        val response = request(HttpMethod.Get, GARMIN_USER_ID_ENDPOINT, this@getExternalId, sourceType)
+        when (response.status) {
+            HttpStatusCode.OK -> withContext(Dispatchers.IO) {
+                response.body<RestOauth1UserId>().userId
+            }
+            HttpStatusCode.BadRequest, HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden -> throw HttpBadGatewayException("Service was unable to fetch the external ID")
+            else -> throw HttpBadGatewayException("Cannot connect to ${response.request.url}: HTTP status ${response.status}")
+        }
+    }
+
+    private fun checkForUsersWithElapsedEndDateAndDeregister() {
+        asyncService.runBlocking {
+            userRepository
+                .queryAllWithElapsedEndDate(GARMIN_AUTH)
+                .forkJoin { revokeToken(it) }
+        }
+    }
+
+    companion object {
+        private const val GARMIN_USER_ID_ENDPOINT = "https://healthapi.garmin.com/wellness-api/rest/user/id"
+        private const val DEREGISTER_CHECK_PERIOD = 3600000L
+    }
+}

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminOAuth2AuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminOAuth2AuthorizationService.kt
@@ -49,7 +49,7 @@ import org.radarbase.kotlin.coroutines.forkJoin
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
-class GarminAuthorizationService(
+class GarminOAuth2AuthorizationService(
     @param:Context private val clientService: RestSourceClientService,
     @param:Context private val registrationRepository: RegistrationRepository,
     @param:Context private val userRepository: RestSourceUserRepository,


### PR DESCRIPTION
This PR re-adds the Garmin OAuth 1 authorization service that was deleted from the base branch and adds conditional logic to register the appropriate authorization service based on the configuration `config.restSourceClients.client.oauthVersion`.
I’m adding this as a separate PR to highlight that the OAuth client configuration will need to be updated during deployment. otherwise, it will default to OAuth 2 for all source types.