### PR TITLE
Add project ID to account already registered error message

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceUserService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/RestSourceUserService.kt
@@ -118,7 +118,7 @@ class RestSourceUserService(
             if (existingUser != null && existingUser.id != user.id) {
                 throw HttpConflictException(
                     "external_user_id_already_exists",
-                    "External user ID ${token.externalUserId} is already registered for another user of source type ${user.sourceType} and user id ${existingUser.userId}",
+                    "External user ID ${token.externalUserId} is already registered for another user with source type ${user.sourceType}, project ${existingUser.projectId}, and user ID ${existingUser.userId}",
                 )
             }
         } else {


### PR DESCRIPTION
Added project ID to the error message when a user tries to register a device account that is already linked to another user, making it easier to identify  which project the existing registration belongs to.