### PR TITLE
User correct user id endpoint for garmin oauth2

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminOAuth2AuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminOAuth2AuthorizationService.kt
@@ -253,7 +253,7 @@ class GarminOAuth2AuthorizationService(
 
     companion object {
         private const val PKCE_CODE_CHALLENGE_METHOD = "S256"
-        private const val GARMIN_USER_ID_ENDPOINT = "https://healthapi.garmin.com/wellness-api/rest/user/id"
+        private const val GARMIN_USER_ID_ENDPOINT = "https://apis.garmin.com/wellness-api/rest/user/id"
         private const val DEREGISTER_CHECK_PERIOD = 3600000L
 
         private fun pkceCodeChallenge(codeVerifier: String) = PkceUtil.generateCodeChallenge(codeVerifier)


### PR DESCRIPTION
I noticed that Garmin uses different user ID endpoints for OAuth1 vs. OAuth2 flows. Right now, this is controlled only by code and not by external configuration.

Therefore, this PR updates the Garmin user ID to refer to the correct URL.