### PR TITLE
fix: CI workflow docker image build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,13 @@ env:
   REPOSITORY: ${{ github.repository }}
   IMAGES: >-
     [{
-    'name': 'authorizer-app-backend',
+    'name': 'radar-rest-source-auth-backend',
     'build_file': 'authorizer-app-backend/Dockerfile',
     'authors': 'Pauline Conde <pauline.conde@kcl.ac.uk>, Pim van Nierop <pim@thehyve.nl>',
     'description': 'RADAR-base rest sources authorizer backend application',
     'cache_keys_files': ['authorizer-app-backend/Dockerfile', '**/*.gradle.kts', 'gradle.properties', 'authorizer-app-backend/src/main/**']
     },{
-    'name': 'authorizer-app',
+    'name': 'radar-rest-source-authorizer',
     'build_file': 'authorizer-app/Dockerfile',
     'authors': 'Peyman Mohtashami <peyman@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>',
     'description': 'RADAR-base rest sources authorizer frontend application',

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ env:
     'name': 'authorizer-app',
     'build_file': 'authorizer-app/Dockerfile',
     'authors': 'Peyman Mohtashami <peyman@thehyve.nl>, Pauline Conde <pauline.conde@kcl.ac.uk>',
-    'description': 'RADAR-base rest sources authorizer frontend application'
+    'description': 'RADAR-base rest sources authorizer frontend application',
     'cache_keys_files': ['authorizer-app/**']
     }]
 


### PR DESCRIPTION
The `fromJson()` call in the `docker` job's matrix strategy was failing due to invalid JSON, causing the job to be skipped. The workflow still showed as green because the other jobs (kotlin, node) passed fine.                                                                                                                 
                                                                                                                                                                     
  Image name changes in `main.yml` for consistency:
  - `authorizer-app-backend` → `radar-rest-source-auth-backend`                                                                                                      
  - `authorizer-app` → `radar-rest-source-authorizer`          
