### PR TITLE
Use speicific logger per oauth service

### DIFF
--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminOAuth2AuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/GarminOAuth2AuthorizationService.kt
@@ -46,6 +46,7 @@ import org.radarbase.jersey.exception.HttpBadGatewayException
 import org.radarbase.jersey.exception.HttpInternalServerException
 import org.radarbase.jersey.service.AsyncCoroutineService
 import org.radarbase.kotlin.coroutines.forkJoin
+import org.slf4j.LoggerFactory
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
@@ -252,6 +253,8 @@ class GarminOAuth2AuthorizationService(
     }
 
     companion object {
+        private val logger = LoggerFactory.getLogger(GarminOAuth2AuthorizationService::class.java)
+
         private const val PKCE_CODE_CHALLENGE_METHOD = "S256"
         private const val GARMIN_USER_ID_ENDPOINT = "https://apis.garmin.com/wellness-api/rest/user/id"
         private const val DEREGISTER_CHECK_PERIOD = 3600000L

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OAuth2RestSourceAuthorizationService.kt
@@ -141,6 +141,6 @@ open class OAuth2RestSourceAuthorizationService(
     }
 
     companion object {
-        val logger: Logger = LoggerFactory.getLogger(OAuth2RestSourceAuthorizationService::class.java)
+        private val logger: Logger = LoggerFactory.getLogger(OAuth2RestSourceAuthorizationService::class.java)
     }
 }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OuraAuthorizationService.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/service/OuraAuthorizationService.kt
@@ -19,6 +19,7 @@ import org.radarbase.authorizer.api.RestOauth2AccessToken
 import org.radarbase.authorizer.config.AuthorizerConfig
 import org.radarbase.authorizer.doa.entity.RestSourceUser
 import org.radarbase.jersey.exception.HttpBadGatewayException
+import org.slf4j.LoggerFactory
 import java.io.IOException
 
 class OuraAuthorizationService(
@@ -106,6 +107,7 @@ class OuraAuthorizationService(
     }
 
     companion object {
+        private val logger = LoggerFactory.getLogger(OuraAuthorizationService::class.java)
         private const val OURA_USER_ID_ENDPOINT = "https://api.ouraring.com/v2/usercollection/personal_info"
     }
 }


### PR DESCRIPTION
Right now, the OAuth2 service implementations use the same logger as the base class, which puts all logs in OAuth2RestSourceAuthorizationService.kt. To make it clear which service the logs belong to (Oura, Garmin, or Fitbit), the loggers are assigned to the specific implementations.