### PR TITLE
Make usesPkce a derived property on RestSourceClient

### DIFF
--- a/authorizer-app-backend/authorizer.yml
+++ b/authorizer-app-backend/authorizer.yml
@@ -27,20 +27,20 @@ restSourceClients:
     clientSecret: <CLIENT_SECRET>
     scope: activity heartrate sleep profile
   # Garmin OAuth2 PKCE configuration.
-  # oauthVersion: "oauth2" selects the GarminOAuth2AuthorizationService;
-  #               "oauth1" selects the legacy GarminOAuth1AuthorizationService.
+  # oauthVersion: OAUTH2 selects the GarminOAuth2AuthorizationService;
+  #               OAUTH1 selects the legacy GarminOAuth1AuthorizationService.
   - sourceType: Garmin
     authorizationEndpoint: https://connect.garmin.com/oauth2Confirm
     tokenEndpoint: https://diauth.garmin.com/di-oauth2-service/oauth/token
     deregistrationEndpoint: https://apis.garmin.com/wellness-api/rest/user/registration
     clientId: <GARMIN_CLIENT_ID>
     clientSecret: <GARMIN_CLIENT_SECRET>
-    oauthVersion: oauth2
+    oauthVersion: OAUTH2
   # Google Health API
   - sourceType: GoogleHealth
     authorizationEndpoint: https://accounts.google.com/o/oauth2/v2/auth
     tokenEndpoint: https://oauth2.googleapis.com/token
     clientId: <GOOGLE_CLIENT_ID>
     clientSecret: <GOOGLE_CLIENT_SECRET>
-    scope: https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.nutrition.readonly https://www.googleapis.com/auth/googlehealth.irn.readonly https://www.googleapis.com/auth/googlehealth.ecg.readonly
-    oauthVersion: oauth2
+    scope: https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly
+    oauthVersion: OAUTH2

--- a/authorizer-app-backend/authorizer.yml
+++ b/authorizer-app-backend/authorizer.yml
@@ -42,5 +42,5 @@ restSourceClients:
     tokenEndpoint: https://oauth2.googleapis.com/token
     clientId: <GOOGLE_CLIENT_ID>
     clientSecret: <GOOGLE_CLIENT_SECRET>
-    scope: https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly
+    scope: https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.irn.readonly https://www.googleapis.com/auth/googlehealth.ecg.readonly https://www.googleapis.com/auth/googlehealth.settings.readonly https://www.googleapis.com/auth/googlehealth.location.readonly
     oauthVersion: OAUTH2

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/OAuthVersion.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/OAuthVersion.kt
@@ -1,0 +1,7 @@
+package org.radarbase.authorizer.config
+
+/** OAuth protocol version configured for a [RestSourceClient]. */
+enum class OAuthVersion {
+    OAUTH1,
+    OAUTH2,
+}

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
@@ -16,20 +16,11 @@ data class RestSourceClient(
     val grantType: String? = null,
     val scope: String? = null,
     val state: String? = null,
-    val oauthVersion: String = "oauth2",
+    val oauthVersion: OAuthVersion = OAuthVersion.OAUTH2,
 ) {
-    val usesOauth2: Boolean
-        get() = when {
-            oauthVersion.equals("oauth2", ignoreCase = true) -> true
-            oauthVersion.equals("oauth1", ignoreCase = true) -> false
-            else -> throw IllegalArgumentException(
-                "Invalid OAuth version for $sourceType: '$oauthVersion'. Expected 'oauth1' or 'oauth2'.",
-            )
-        }
-
     val usesPkce: Boolean
         get() = when {
-            sourceType == GARMIN_AUTH && usesOauth2 -> true
+            sourceType == GARMIN_AUTH && oauthVersion == OAuthVersion.OAUTH2 -> true
             sourceType == GOOGLE_AUTH -> true
             else -> false
         }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
@@ -20,7 +20,6 @@ data class RestSourceClient(
         get() = when {
             sourceType == "Garmin" && oauthVersion.equals("oauth2", ignoreCase = true) -> true
             sourceType == "Google" -> true
-            sourceType == "Oura" -> true
             else -> false
         }
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
@@ -1,5 +1,7 @@
 package org.radarbase.authorizer.config
 
+import org.radarbase.authorizer.service.DelegatedRestSourceAuthorizationService.Companion.GARMIN_AUTH
+import org.radarbase.authorizer.service.DelegatedRestSourceAuthorizationService.Companion.GOOGLE_AUTH
 import org.radarbase.jersey.config.ConfigLoader.copyEnv
 import java.util.Locale
 
@@ -16,10 +18,19 @@ data class RestSourceClient(
     val state: String? = null,
     val oauthVersion: String = "oauth2",
 ) {
+    val usesOauth2: Boolean
+        get() = when {
+            oauthVersion.equals("oauth2", ignoreCase = true) -> true
+            oauthVersion.equals("oauth1", ignoreCase = true) -> false
+            else -> throw IllegalArgumentException(
+                "Invalid OAuth version for $sourceType: '$oauthVersion'. Expected 'oauth1' or 'oauth2'.",
+            )
+        }
+
     val usesPkce: Boolean
         get() = when {
-            sourceType == "Garmin" && oauthVersion.equals("oauth2", ignoreCase = true) -> true
-            sourceType == "Google" -> true
+            sourceType == GARMIN_AUTH && usesOauth2 -> true
+            sourceType == GOOGLE_AUTH -> true
             else -> false
         }
 

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/config/RestSourceClient.kt
@@ -14,9 +14,16 @@ data class RestSourceClient(
     val grantType: String? = null,
     val scope: String? = null,
     val state: String? = null,
-    val usesPkce: Boolean = false,
     val oauthVersion: String = "oauth2",
 ) {
+    val usesPkce: Boolean
+        get() = when {
+            sourceType == "Garmin" && oauthVersion.equals("oauth2", ignoreCase = true) -> true
+            sourceType == "Google" -> true
+            sourceType == "Oura" -> true
+            else -> false
+        }
+
     fun withEnv(): RestSourceClient =
         this.copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_ID") { copy(clientId = it) }
             .copyEnv("${sourceType.uppercase(Locale.US)}_CLIENT_SECRET") { copy(clientSecret = it) }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
@@ -48,15 +48,6 @@ class AuthorizerResourceEnhancer(
     private val restSourceClients = RestSourceClients(
         config.restSourceClients
             .map { it.withEnv() }
-            .map {
-                when {
-                    it.sourceType == GARMIN_AUTH && it.oauthVersion.equals("oauth2", ignoreCase = true) ->
-                        it.copy(usesPkce = true)
-                    it.sourceType == GOOGLE_AUTH ->
-                        it.copy(usesPkce = true)
-                    else -> it
-                }
-            }
             .onEach {
                 requireNotNull(it.clientId) { "Client ID of ${it.sourceType} is missing" }
                 requireNotNull(it.clientSecret) { "Client secret of ${it.sourceType} is missing" }

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
@@ -21,6 +21,7 @@ import org.glassfish.jersey.internal.inject.AbstractBinder
 import org.radarbase.authorizer.api.RestSourceClientMapper
 import org.radarbase.authorizer.api.RestSourceUserMapper
 import org.radarbase.authorizer.config.AuthorizerConfig
+import org.radarbase.authorizer.config.OAuthVersion
 import org.radarbase.authorizer.config.RestSourceClients
 import org.radarbase.authorizer.doa.RegistrationRepository
 import org.radarbase.authorizer.doa.RestSourceUserRepository
@@ -55,7 +56,7 @@ class AuthorizerResourceEnhancer(
     )
 
     private val garminUsesOauth2 = restSourceClients.clients
-        .firstOrNull { it.sourceType == GARMIN_AUTH }?.usesOauth2 == true
+        .firstOrNull { it.sourceType == GARMIN_AUTH }?.oauthVersion == OAuthVersion.OAUTH2
 
     override val classes: Array<Class<*>>
         get() = listOfNotNull(

--- a/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
+++ b/authorizer-app-backend/src/main/java/org/radarbase/authorizer/enhancer/AuthorizerResourceEnhancer.kt
@@ -54,6 +54,9 @@ class AuthorizerResourceEnhancer(
             },
     )
 
+    private val garminUsesOauth2 = restSourceClients.clients
+        .firstOrNull { it.sourceType == GARMIN_AUTH }?.usesOauth2 == true
+
     override val classes: Array<Class<*>>
         get() = listOfNotNull(
             Filters.cache,
@@ -105,9 +108,7 @@ class AuthorizerResourceEnhancer(
         bind(DelegatedRestSourceAuthorizationService::class.java)
             .to(RestSourceAuthorizationService::class.java)
 
-        // Bind Garmin service based on configured oauthVersion: "oauth2" → PKCE flow, "oauth1" → legacy flow.
-        val garminUsesPkce = restSourceClients.clients.firstOrNull { it.sourceType == GARMIN_AUTH }?.usesPkce == true
-        if (garminUsesPkce) {
+        if (garminUsesOauth2) {
             bind(GarminOAuth2AuthorizationService::class.java)
                 .to(RestSourceAuthorizationService::class.java)
                 .named(GARMIN_AUTH)

--- a/docker/etc/rest-source-authorizer/authorizer.yml
+++ b/docker/etc/rest-source-authorizer/authorizer.yml
@@ -37,14 +37,12 @@ restSourceClients:
     clientSecret: Oura-clinetsecret
     scope: daily session heartrate workout tag personal email spo2 ring_configuration
   # Garmin OAuth2 PKCE configuration.
-  # oauthVersion: "oauth2" selects the GarminOAuth2AuthorizationService;
-  #   "oauth1" selects the legacy GarminOAuth1AuthorizationService.
-  # usesPkce: must be true for Garmin OAuth2 (Garmin requires PKCE).
+  # oauthVersion: OAUTH2 selects the GarminOAuth2AuthorizationService;
+  #   OAUTH1 selects the legacy GarminOAuth1AuthorizationService.
   - sourceType: Garmin
     authorizationEndpoint: https://connect.garmin.com/oauth2Confirm
     tokenEndpoint: https://diauth.garmin.com/di-oauth2-service/oauth/token
     deregistrationEndpoint: https://apis.garmin.com/wellness-api/rest/user/registration
     clientId: Garmin-clientid
     clientSecret: Garmin-clientsecret
-    oauthVersion: oauth2
-    usesPkce: true
+    oauthVersion: OAUTH2


### PR DESCRIPTION
Derive `usesPkce` in rest source client and remove it from constructor param so it can never be added to the configs.