### PR TITLE
Make add_code_verifier changeset idempotent to fix staging re-run

### DIFF
--- a/authorizer-app-backend/src/main/resources/db/changelog/changes/20260204120000_add_code_verifier_column.xml
+++ b/authorizer-app-backend/src/main/resources/db/changelog/changes/20260204120000_add_code_verifier_column.xml
@@ -6,6 +6,11 @@
                         https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd">
 
     <changeSet author="aditya" id="20260204120000-add-code-verifier-column">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="registration" columnName="code_verifier"/>
+            </not>
+        </preConditions>
         <addColumn tableName="registration">
             <column name="code_verifier" type="varchar(128)">
                 <constraints nullable="true"/>


### PR DESCRIPTION
 While testing on stage, I noticed the last deployed changeset id contained `.xml`, while the current changelog id does not. Liquibase treat it as a new changeset and re-run the `addColumn` on the next deployment, failing  with `column "code_verifier" already exists` and blocking app startup.

This PR adds a `preConditions` check: if the `code_verifier` column already  exists, mark the changeset as run  instead of failing. This `.xml`-suffixed id was only deployed to staging it was never deployed to production. So this fix specifically unblocks the staging deployment.

