### PR TITLE
Rename source type to GoogleHealth in configs

### DIFF
--- a/authorizer-app-backend/authorizer.yml
+++ b/authorizer-app-backend/authorizer.yml
@@ -37,7 +37,7 @@ restSourceClients:
     clientSecret: <GARMIN_CLIENT_SECRET>
     oauthVersion: oauth2
   # Google Health API
-  - sourceType: Google
+  - sourceType: GoogleHealth
     authorizationEndpoint: https://accounts.google.com/o/oauth2/v2/auth
     tokenEndpoint: https://oauth2.googleapis.com/token
     clientId: <GOOGLE_CLIENT_ID>


### PR DESCRIPTION
As per the discussion of PR: https://github.com/RADAR-base/RADAR-Rest-Source-Auth/pull/332, it is decided to rename the source type from `Google` to `GoogleHealth`. But I missed to update this in configs. This PR just does the remaining update.